### PR TITLE
[SL-236] Add symbols and abbreviations table to MIS document

### DIFF
--- a/docs/Design/SoftDetailedDes/MIS.tex
+++ b/docs/Design/SoftDetailedDes/MIS.tex
@@ -61,7 +61,23 @@ urlcolor=cyan          % color of external links
 
 \section{Symbols, Abbreviations and Acronyms}
 
-See SRS Documentation at \href{https://github.com/4G06-Streamliners/MacSync-SRS/blob/main/index.pdf}{SRS} and MG Documentation at \href{https://github.com/4G06-Streamliners/MacSync/blob/main/docs/Design/SoftArchitecture/MG.pdf}{MG}.
+\renewcommand{\arraystretch}{1.2}
+\begin{tabular}{l l} 
+  \toprule		
+  \textbf{symbol} & \textbf{description}\\
+  \midrule 
+  AC & Anticipated Change\\
+  DAG & Directed Acyclic Graph \\
+  M & Module \\
+  MG & Module Guide \\
+  OS & Operating System \\
+  R & Requirement\\
+  SC & Scientific Computing \\
+  SRS & Software Requirements Specification\\
+  \progname & Explanation of program name\\
+  UC & Unlikely Change \\
+  \bottomrule
+\end{tabular}\\
 
 \newpage
 


### PR DESCRIPTION
Address TA feedback to Add symbols and abbreviations table to MIS document