### PR TITLE
[SL-259] Admin panel auth and role-based access control

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -229,6 +229,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3200,6 +3201,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3370,6 +3372,7 @@
       "resolved": "https://registry.npmmirror.com/@nestjs/common/-/common-11.1.13.tgz",
       "integrity": "sha512-ieqWtipT+VlyDWLz5Rvz0f3E5rXcVAnaAi+D53DEHLjc1kmFxCgZ62qVfTX2vwkywwqNkTNXvBgGR72hYqV//Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3402,6 +3405,7 @@
       "integrity": "sha512-Tq9EIKiC30EBL8hLK93tNqaToy0hzbuVGYt29V8NhkVJUsDzlmiVf6c3hSPtzx2krIUVbTgQ2KFeaxr72rEyzQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3442,6 +3446,7 @@
       "resolved": "https://registry.npmmirror.com/@nestjs/platform-express/-/platform-express-11.1.13.tgz",
       "integrity": "sha512-LYmi43BrAs1n74kLCUfXcHag7s1CmGETcFbf9IVyA/KWXAuAH95G3wEaZZiyabOLFNwq4ifnRGnIwUwW7cz3+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3857,6 +3862,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3988,6 +3994,7 @@
       "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4008,6 +4015,7 @@
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4142,6 +4150,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4829,6 +4838,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4878,6 +4888,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5313,6 +5324,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5517,6 +5529,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6412,6 +6425,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6472,6 +6486,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7858,6 +7873,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9663,6 +9679,7 @@
       "resolved": "https://registry.npmmirror.com/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -9948,6 +9965,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10167,7 +10185,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmmirror.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -10298,6 +10317,7 @@
       "resolved": "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10980,6 +11000,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11328,6 +11349,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11475,6 +11497,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11812,7 +11835,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -11831,7 +11853,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11845,7 +11866,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -11860,7 +11880,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11870,8 +11889,7 @@
       "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -11879,7 +11897,6 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11890,7 +11907,6 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -11904,7 +11920,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -229,7 +229,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3201,7 +3200,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3372,7 +3370,6 @@
       "resolved": "https://registry.npmmirror.com/@nestjs/common/-/common-11.1.13.tgz",
       "integrity": "sha512-ieqWtipT+VlyDWLz5Rvz0f3E5rXcVAnaAi+D53DEHLjc1kmFxCgZ62qVfTX2vwkywwqNkTNXvBgGR72hYqV//Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3405,7 +3402,6 @@
       "integrity": "sha512-Tq9EIKiC30EBL8hLK93tNqaToy0hzbuVGYt29V8NhkVJUsDzlmiVf6c3hSPtzx2krIUVbTgQ2KFeaxr72rEyzQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3446,7 +3442,6 @@
       "resolved": "https://registry.npmmirror.com/@nestjs/platform-express/-/platform-express-11.1.13.tgz",
       "integrity": "sha512-LYmi43BrAs1n74kLCUfXcHag7s1CmGETcFbf9IVyA/KWXAuAH95G3wEaZZiyabOLFNwq4ifnRGnIwUwW7cz3+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3862,7 +3857,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3994,7 +3988,6 @@
       "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4015,7 +4008,6 @@
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4150,7 +4142,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4838,7 +4829,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4888,7 +4878,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5324,7 +5313,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5529,7 +5517,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6425,7 +6412,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6486,7 +6472,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7873,7 +7858,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9679,7 +9663,6 @@
       "resolved": "https://registry.npmmirror.com/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -9965,7 +9948,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10185,8 +10167,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmmirror.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -10317,7 +10298,6 @@
       "resolved": "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11000,7 +10980,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11349,7 +11328,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11497,7 +11475,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11835,6 +11812,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -11853,6 +11831,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11866,6 +11845,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -11880,6 +11860,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11889,7 +11870,8 @@
       "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -11897,6 +11879,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11907,6 +11890,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -11920,6 +11904,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/src/backend/src/auth/auth.controller.ts
+++ b/src/backend/src/auth/auth.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Post,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { OnboardingGuard } from './onboarding.guard';

--- a/src/backend/src/auth/auth.service.ts
+++ b/src/backend/src/auth/auth.service.ts
@@ -329,6 +329,8 @@ export class AuthService {
       });
     }
 
+    // Ensure new/onboarding users get Member role so they can sign up for events
+    await this.usersService.replaceRoles(user.id, ['Member']);
     const userWithRoles = await this.usersService.findOneWithRoles(user.id);
     const token = this.issueJwt({ sub: user.id, email: user.email });
 

--- a/src/backend/src/auth/auth.service.ts
+++ b/src/backend/src/auth/auth.service.ts
@@ -121,9 +121,9 @@ export class AuthService {
       (user.firstName?.trim() && user.lastName?.trim()) || user.name?.trim();
     return Boolean(
       hasName &&
-        user.phoneNumber?.trim() &&
-        user.program?.trim() &&
-        user.passwordHash?.trim(),
+      user.phoneNumber?.trim() &&
+      user.program?.trim() &&
+      user.passwordHash?.trim(),
     );
   }
 

--- a/src/backend/src/auth/jwt-auth.guard.ts
+++ b/src/backend/src/auth/jwt-auth.guard.ts
@@ -17,19 +17,17 @@ export class JwtAuthGuard implements CanActivate {
     // M8: validateToken(token) -> verify JWT before protected routes.
     const request = context.switchToHttp().getRequest<RequestWithHeaders>();
     const header = request.headers?.authorization ?? '';
-    const token = typeof header === 'string' && header.startsWith('Bearer ')
-      ? header.slice(7).trim()
-      : null;
+    const token =
+      typeof header === 'string' && header.startsWith('Bearer ')
+        ? header.slice(7).trim()
+        : null;
 
     if (!token) {
       throw new UnauthorizedException('Missing authorization token.');
     }
 
     try {
-      const decoded = verify(
-        token,
-        process.env.JWT_SECRET || 'dev-secret',
-      );
+      const decoded = verify(token, process.env.JWT_SECRET || 'dev-secret');
 
       if (typeof decoded !== 'object' || decoded === null) {
         throw new UnauthorizedException('Invalid token payload.');

--- a/src/backend/src/auth/onboarding.guard.ts
+++ b/src/backend/src/auth/onboarding.guard.ts
@@ -16,19 +16,17 @@ export class OnboardingGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<RequestWithHeaders>();
     const header = request.headers?.authorization ?? '';
-    const token = typeof header === 'string' && header.startsWith('Bearer ')
-      ? header.slice(7).trim()
-      : null;
+    const token =
+      typeof header === 'string' && header.startsWith('Bearer ')
+        ? header.slice(7).trim()
+        : null;
 
     if (!token) {
       throw new UnauthorizedException('Missing onboarding token.');
     }
 
     try {
-      const decoded = verify(
-        token,
-        process.env.JWT_SECRET || 'dev-secret',
-      );
+      const decoded = verify(token, process.env.JWT_SECRET || 'dev-secret');
 
       if (typeof decoded !== 'object' || decoded === null) {
         throw new UnauthorizedException('Invalid onboarding token.');

--- a/src/backend/src/auth/roles.decorator.ts
+++ b/src/backend/src/auth/roles.decorator.ts
@@ -1,0 +1,10 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+
+/**
+ * Declare which roles are allowed to access a route.
+ * Example: @Roles('Admin') or @Roles('Admin', 'Member')
+ */
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);
+

--- a/src/backend/src/auth/roles.decorator.ts
+++ b/src/backend/src/auth/roles.decorator.ts
@@ -7,4 +7,3 @@ export const ROLES_KEY = 'roles';
  * Example: @Roles('Admin') or @Roles('Admin', 'Member')
  */
 export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);
-

--- a/src/backend/src/auth/roles.guard.ts
+++ b/src/backend/src/auth/roles.guard.ts
@@ -33,7 +33,14 @@ export class RolesGuard implements CanActivate {
       throw new ForbiddenException('Access denied.');
     }
 
-    const dbUser = await this.usersService.findOneWithRoles(user.sub);
+    let dbUser;
+    try {
+      dbUser = await this.usersService.findOneWithRoles(user.sub);
+    } catch (err) {
+      console.error('[RolesGuard] findOneWithRoles error:', err);
+      throw new ForbiddenException('Access denied.');
+    }
+
     if (!dbUser) {
       throw new ForbiddenException('Access denied.');
     }

--- a/src/backend/src/auth/roles.guard.ts
+++ b/src/backend/src/auth/roles.guard.ts
@@ -1,0 +1,55 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+import { UsersService } from '../users/users.service';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles =
+      this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]);
+
+    // If no roles metadata is present, allow the request (JwtAuthGuard still applies).
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as { sub?: number } | undefined;
+    if (!user?.sub) {
+      throw new ForbiddenException('Access denied.');
+    }
+
+    const dbUser = await this.usersService.findOneWithRoles(user.sub);
+    if (!dbUser) {
+      throw new ForbiddenException('Access denied.');
+    }
+
+    const userRoles = new Set(dbUser.roles ?? []);
+    // Treat isSystemAdmin as implicit 'Admin' role for RBAC checks.
+    if ((dbUser as any).isSystemAdmin) {
+      userRoles.add('Admin');
+    }
+
+    const hasRole = requiredRoles.some((role) => userRoles.has(role));
+    if (!hasRole) {
+      throw new ForbiddenException('Access denied.');
+    }
+
+    return true;
+  }
+}
+

--- a/src/backend/src/common/http-exception.filter.ts
+++ b/src/backend/src/common/http-exception.filter.ts
@@ -1,0 +1,43 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AllExceptionsFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<FastifyReply>();
+    const request = ctx.getRequest<FastifyRequest>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const message =
+      exception instanceof HttpException
+        ? exception.getResponse()
+        : exception instanceof Error
+          ? exception.message
+          : 'Internal server error';
+
+    this.logger.error(
+      `${request.method} ${request.url} -> ${status}\n` +
+        (exception instanceof Error ? exception.stack : String(exception)),
+    );
+
+    response.status(status).send({
+      statusCode: status,
+      error: status >= 500 ? 'Internal Server Error' : 'Bad Request',
+      message: typeof message === 'object' ? (message as { message?: string }).message ?? message : message,
+    });
+  }
+}

--- a/src/backend/src/common/http-exception.filter.ts
+++ b/src/backend/src/common/http-exception.filter.ts
@@ -37,7 +37,10 @@ export class AllExceptionsFilter implements ExceptionFilter {
     response.status(status).send({
       statusCode: status,
       error: status >= 500 ? 'Internal Server Error' : 'Bad Request',
-      message: typeof message === 'object' ? (message as { message?: string }).message ?? message : message,
+      message:
+        typeof message === 'object'
+          ? ((message as { message?: string }).message ?? message)
+          : message,
     });
   }
 }

--- a/src/backend/src/db/README.md
+++ b/src/backend/src/db/README.md
@@ -3,7 +3,7 @@
 ## Tables
 
 - **users** – Profile (email, name, phoneNumber, program, isSystemAdmin)
-- **roles** – Role names (Admin, Member, Guest)
+- **roles** – Role names (Admin, Member)
 - **user_roles** – Many-to-many user ↔ role
 - **events** – Events with optional table/bus config:
   - `tableCount`, `seatsPerTable` → table seats (user picks table + seat)

--- a/src/backend/src/db/seed-data.ts
+++ b/src/backend/src/db/seed-data.ts
@@ -22,32 +22,46 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
     return false; // already seeded
   }
 
-  const [roleAdmin, roleMember, roleGuest] = await db
+  const [roleAdmin, roleMember] = await db
     .insert(roles)
-    .values([{ name: 'Admin' }, { name: 'Member' }, { name: 'Guest' }])
+    .values([
+      { name: 'Admin' },
+      { name: 'Member' },
+    ])
     .returning();
 
   const [user1, user2, user3] = await db
     .insert(users)
     .values([
       {
-        email: 'admin@example.com',
+        email: 'admin@mcmaster.ca',
         name: 'Admin User',
+        firstName: 'Admin',
+        lastName: 'User',
         phoneNumber: '+15551234567',
         program: 'CS',
         isSystemAdmin: true,
+        passwordHash: '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6', // e.g. for Password123
       },
       {
-        email: 'alice@example.com',
+        email: 'alice@mcmaster.ca',
         name: 'Alice Smith',
+        firstName: 'Alice',
+        lastName: 'Smith',
         phoneNumber: '+15559876543',
         program: 'Engineering',
+        // Same dev password as admin (Password123).
+        passwordHash: '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6',
       },
       {
-        email: 'bob@example.com',
+        email: 'bob@mcmaster.ca',
         name: 'Bob Jones',
+        firstName: 'Bob',
+        lastName: 'Jones',
         phoneNumber: '+15555555555',
-        program: null,
+        program: 'Science',
+        // Same dev password as admin (Password123).
+        passwordHash: '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6',
       },
     ])
     .returning();
@@ -56,7 +70,7 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
   await db.insert(userRoles).values([
     { userId: user1.id, roleId: roleAdmin.id },
     { userId: user2.id, roleId: roleMember.id },
-    { userId: user3.id, roleId: roleGuest.id },
+    { userId: user3.id, roleId: roleMember.id },
   ]);
 
   const [event1, event2] = await db

--- a/src/backend/src/db/seed-data.ts
+++ b/src/backend/src/db/seed-data.ts
@@ -27,10 +27,7 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
 
   const [roleAdmin, roleMember] = await db
     .insert(roles)
-    .values([
-      { name: 'Admin' },
-      { name: 'Member' },
-    ])
+    .values([{ name: 'Admin' }, { name: 'Member' }])
     .returning();
 
   const [user1, user2, user3] = await db
@@ -44,7 +41,8 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
         phoneNumber: '+15551234567',
         program: 'CS',
         isSystemAdmin: true,
-        passwordHash: '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6', // e.g. for Password123
+        passwordHash:
+          '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6', // e.g. for Password123
       },
       {
         email: 'alice@mcmaster.ca',
@@ -54,7 +52,8 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
         phoneNumber: '+15559876543',
         program: 'Engineering',
         // Same dev password as admin (Password123).
-        passwordHash: '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6',
+        passwordHash:
+          '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6',
       },
       {
         email: 'bob@mcmaster.ca',
@@ -64,7 +63,8 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
         phoneNumber: '+15555555555',
         program: 'Science',
         // Same dev password as admin (Password123).
-        passwordHash: '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6',
+        passwordHash:
+          '$2b$10$gNGCkz3TUVsAJOaBK1ttW..Vjx6AQJkqw0l34eiAFf.rKsqqYF7o6',
       },
     ])
     .returning();
@@ -159,7 +159,7 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
   let ticket1: Ticket | undefined;
   let ticket2: Ticket | undefined;
   let ticket3: Ticket | undefined;
-  
+
   if (existingTickets.length > 0) {
     // Update existing tickets with QR codes
     const allTickets: Ticket[] = await db.select().from(tickets);
@@ -180,49 +180,58 @@ export async function runSeedDb(db: SeedDb): Promise<boolean> {
     const [t1, t2, t3] = await db
       .insert(tickets)
       .values([
-        { 
-          userId: user1.id, 
+        {
+          userId: user1.id,
           eventId: event1.id,
-          qrCodeData: `TICKET:${user1.id}:${event1.id}:temp1:${timestamp}`
+          qrCodeData: `TICKET:${user1.id}:${event1.id}:temp1:${timestamp}`,
         },
-        { 
-          userId: user2.id, 
+        {
+          userId: user2.id,
           eventId: event1.id,
-          qrCodeData: `TICKET:${user2.id}:${event1.id}:temp2:${timestamp}`
+          qrCodeData: `TICKET:${user2.id}:${event1.id}:temp2:${timestamp}`,
         },
-        { 
-          userId: user3.id, 
+        {
+          userId: user3.id,
           eventId: event2.id,
-          qrCodeData: `TICKET:${user3.id}:${event2.id}:temp3:${timestamp}`
+          qrCodeData: `TICKET:${user3.id}:${event2.id}:temp3:${timestamp}`,
         },
       ])
       .returning();
-    
+
     // Update with actual ticket IDs
     if (t1) {
       await db
         .update(tickets)
-        .set({ qrCodeData: `TICKET:${user1.id}:${event1.id}:${t1.id}:${timestamp}`, updatedAt: new Date() })
+        .set({
+          qrCodeData: `TICKET:${user1.id}:${event1.id}:${t1.id}:${timestamp}`,
+          updatedAt: new Date(),
+        })
         .where(eq(tickets.id, t1.id));
     }
     if (t2) {
       await db
         .update(tickets)
-        .set({ qrCodeData: `TICKET:${user2.id}:${event1.id}:${t2.id}:${timestamp}`, updatedAt: new Date() })
+        .set({
+          qrCodeData: `TICKET:${user2.id}:${event1.id}:${t2.id}:${timestamp}`,
+          updatedAt: new Date(),
+        })
         .where(eq(tickets.id, t2.id));
     }
     if (t3) {
       await db
         .update(tickets)
-        .set({ qrCodeData: `TICKET:${user3.id}:${event2.id}:${t3.id}:${timestamp}`, updatedAt: new Date() })
+        .set({
+          qrCodeData: `TICKET:${user3.id}:${event2.id}:${t3.id}:${timestamp}`,
+          updatedAt: new Date(),
+        })
         .where(eq(tickets.id, t3.id));
     }
-    
+
     ticket1 = t1;
     ticket2 = t2;
     ticket3 = t3;
   }
-  
+
   if (!ticket1 || !ticket2 || !ticket3) throw new Error('Ticket insert failed');
 
   if (ticket1 && ticket2) {

--- a/src/backend/src/events/events.controller.ts
+++ b/src/backend/src/events/events.controller.ts
@@ -30,13 +30,11 @@ export class EventsController {
   ) {}
 
   @Get()
-  @Roles('Admin', 'Member')
   findAll() {
     return this.eventsService.findAll();
   }
 
   @Get(':id')
-  @Roles('Admin', 'Member')
   findOne(@Param('id') id: string, @Query('userId') userId?: string) {
     const uid = userId != null && userId !== '' ? +userId : undefined;
     return this.eventsService.findOne(+id, uid);
@@ -61,17 +59,23 @@ export class EventsController {
   }
 
   @Post(':id/signup')
-  @Roles('Member', 'Admin')
-  signup(
+  async signup(
     @Param('id') id: string,
     @Req() req: RequestWithUser,
     @Body('selectedTable') selectedTable?: number,
   ) {
-    return this.eventsService.signup(+id, req.user.sub, selectedTable);
+    try {
+      return await this.eventsService.signup(+id, req.user.sub, selectedTable);
+    } catch (err) {
+      console.error('[signup] Error:', err);
+      if (err instanceof Error) {
+        console.error('[signup] Stack:', err.stack);
+      }
+      throw err;
+    }
   }
 
   @Post(':id/checkout-session')
-  @Roles('Member', 'Admin')
   createCheckoutSession(
     @Param('id') id: string,
     @Req() req: RequestWithUser,
@@ -114,7 +118,6 @@ export class EventsController {
   // Called by the client when Stripe redirects to cancel_url.
   // Releases the held seat immediately so the user can retry without waiting for expiry.
   @Post('checkout-session/:sessionId/release')
-  @Roles('Member', 'Admin')
   async releaseCheckoutReservation(@Param('sessionId') sessionId: string) {
     console.log(
       '[releaseCheckoutReservation] Releasing reservation for session:',
@@ -126,13 +129,11 @@ export class EventsController {
   }
 
   @Post(':id/cancel')
-  @Roles('Member', 'Admin')
   cancelSignup(@Param('id') id: string, @Req() req: RequestWithUser) {
     return this.eventsService.cancelSignup(+id, req.user.sub);
   }
 
   @Get('user/:userId/tickets')
-  @Roles('Admin', 'Member')
   async getUserTickets(
     @Param('userId') userId: string,
     @Req() req: RequestWithUser,

--- a/src/backend/src/events/events.controller.ts
+++ b/src/backend/src/events/events.controller.ts
@@ -1,52 +1,63 @@
 import {
+  Body,
   Controller,
+  Delete,
+  ForbiddenException,
   Get,
+  Param,
   Post,
   Put,
-  Delete,
-  Body,
-  Param,
   Query,
   Req,
   UseGuards,
-  ForbiddenException,
 } from '@nestjs/common';
+import { UsersService } from '../users/users.service';
 import { EventsService } from './events.service';
 import type { NewEvent } from '../db/schema';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
 
 @Controller('events')
 @UseGuards(JwtAuthGuard)
 export class EventsController {
-  constructor(private readonly eventsService: EventsService) {}
+  constructor(
+    private readonly eventsService: EventsService,
+    private readonly usersService: UsersService,
+  ) {}
 
   @Get()
+  @Roles('Admin', 'Member')
   findAll() {
     return this.eventsService.findAll();
   }
 
   @Get(':id')
+  @Roles('Admin', 'Member')
   findOne(@Param('id') id: string, @Query('userId') userId?: string) {
     const uid = userId != null && userId !== '' ? +userId : undefined;
     return this.eventsService.findOne(+id, uid);
   }
 
   @Post()
+  @Roles('Admin')
   create(@Body() event: NewEvent) {
     return this.eventsService.create(event);
   }
 
   @Put(':id')
+  @Roles('Admin')
   update(@Param('id') id: string, @Body() event: Partial<NewEvent>) {
     return this.eventsService.update(+id, event);
   }
 
   @Delete(':id')
+  @Roles('Admin')
   delete(@Param('id') id: string) {
     return this.eventsService.delete(+id);
   }
 
   @Post(':id/signup')
+  @Roles('Member', 'Admin')
   signup(
     @Param('id') id: string,
     @Req() req: any,
@@ -56,6 +67,7 @@ export class EventsController {
   }
 
   @Post(':id/checkout-session')
+  @Roles('Member', 'Admin')
   createCheckoutSession(
     @Param('id') id: string,
     @Req() req: any,
@@ -98,6 +110,7 @@ export class EventsController {
   // Called by the client when Stripe redirects to cancel_url.
   // Releases the held seat immediately so the user can retry without waiting for expiry.
   @Post('checkout-session/:sessionId/release')
+  @Roles('Member', 'Admin')
   async releaseCheckoutReservation(@Param('sessionId') sessionId: string) {
     console.log(
       '[releaseCheckoutReservation] Releasing reservation for session:',
@@ -109,14 +122,30 @@ export class EventsController {
   }
 
   @Post(':id/cancel')
+  @Roles('Member', 'Admin')
   cancelSignup(@Param('id') id: string, @Req() req: any) {
     return this.eventsService.cancelSignup(+id, req.user.sub);
   }
 
   @Get('user/:userId/tickets')
-  getUserTickets(@Param('userId') userId: string, @Req() req: any) {
-    if (req.user?.sub !== +userId) {
+  @Roles('Admin', 'Member')
+  async getUserTickets(
+    @Param('userId') userId: string,
+    @Req() req: any,
+  ) {
+    const currentUserId = req.user?.sub;
+    if (!currentUserId) {
       throw new ForbiddenException('Access denied.');
+    }
+    // Allow: self-access (user fetching own tickets) OR admin
+    if (currentUserId !== +userId) {
+      const dbUser = await this.usersService.findOneWithRoles(currentUserId);
+      const isAdmin =
+        (dbUser as { isSystemAdmin?: boolean })?.isSystemAdmin ||
+        (dbUser?.roles ?? []).includes('Admin');
+      if (!isAdmin) {
+        throw new ForbiddenException('Access denied.');
+      }
     }
     return this.eventsService.getTicketsForUser(+userId);
   }

--- a/src/backend/src/events/events.module.ts
+++ b/src/backend/src/events/events.module.ts
@@ -3,11 +3,13 @@ import { EventsController } from './events.controller';
 import { EventsService } from './events.service';
 import { DatabaseModule } from '../database/database.module';
 import { PaymentsModule } from '../payments/payments.module';
+import { UsersModule } from '../users/users.module';
+import { RolesGuard } from '../auth/roles.guard';
 
 @Module({
-  imports: [DatabaseModule, PaymentsModule],
+  imports: [DatabaseModule, PaymentsModule, UsersModule],
   controllers: [EventsController],
-  providers: [EventsService],
+  providers: [EventsService, RolesGuard],
   exports: [EventsService],
 })
 export class EventsModule {}

--- a/src/backend/src/events/events.service.ts
+++ b/src/backend/src/events/events.service.ts
@@ -10,7 +10,7 @@ import {
   seatReservations,
 } from '../db/schema';
 import type { NewEvent } from '../db/schema';
-import { eq, sql, and } from 'drizzle-orm';
+import { eq, sql, and, asc } from 'drizzle-orm';
 import type { SeedDb } from '../db/seed-data';
 import {
   createTableSeatsForEvent,
@@ -417,6 +417,9 @@ export class EventsService {
       .values({ userId, eventId })
       .returning();
     const ticket = result[0];
+    if (!ticket) {
+      return { error: 'Failed to create ticket. Please try again.' };
+    }
 
     // Generate and update QR code data
     const qrCodeData = this.generateQRCodeData(ticket.id, userId, eventId);
@@ -574,6 +577,9 @@ export class EventsService {
       .values({ userId, eventId })
       .returning();
     const ticket = result[0];
+    if (!ticket) {
+      return { error: 'Failed to create ticket. Please try again.' };
+    }
 
     // Generate and update QR code data
     const qrCodeData = this.generateQRCodeData(ticket.id, userId, eventId);
@@ -598,7 +604,7 @@ export class EventsService {
         .select()
         .from(tableSeats)
         .where(conditions)
-        .orderBy(tableSeats.tableNumber, tableSeats.seatNumber)
+        .orderBy(asc(tableSeats.tableNumber), asc(tableSeats.seatNumber))
         .limit(1);
 
       if (availableTableSeat[0]) {
@@ -617,7 +623,7 @@ export class EventsService {
         .where(
           sql`${busSeats.eventId} = ${eventId} AND ${busSeats.ticketId} IS NULL`,
         )
-        .orderBy(busSeats.busNumber, busSeats.seatNumber)
+        .orderBy(asc(busSeats.busNumber), asc(busSeats.seatNumber))
         .limit(1);
       if (availableBusSeat[0]) {
         await this.dbService.db

--- a/src/backend/src/main.ts
+++ b/src/backend/src/main.ts
@@ -41,10 +41,11 @@ async function bootstrap() {
     },
   );
 
-  // Enable CORS for all origins
+  // Enable CORS for all origins, including non-GET methods used by the admin panel
   await app.register(cors, {
-    origin: true, // Allow all origins
+    origin: true, // Allow all origins (dev)
     credentials: true,
+    methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
   });
 
   await app.listen(process.env.PORT ?? 3000, '0.0.0.0');

--- a/src/backend/src/main.ts
+++ b/src/backend/src/main.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/platform-fastify';
 import cors from '@fastify/cors';
 import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './common/http-exception.filter';
 
 interface RequestWithUrlAndRawBody {
   url?: string;
@@ -18,6 +19,8 @@ async function bootstrap() {
     AppModule,
     new FastifyAdapter(),
   );
+
+  app.useGlobalFilters(new AllExceptionsFilter());
 
   const fastifyInstance = app.getHttpAdapter().getInstance();
 

--- a/src/backend/src/stats/stats.controller.ts
+++ b/src/backend/src/stats/stats.controller.ts
@@ -1,11 +1,15 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { StatsService, type DashboardStats } from './stats.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
 
 @Controller('admin')
+@UseGuards(JwtAuthGuard)
 export class StatsController {
   constructor(private readonly statsService: StatsService) {}
 
   @Get('stats')
+  @Roles('Admin')
   getDashboardStats(): Promise<DashboardStats> {
     return this.statsService.getDashboardStats();
   }

--- a/src/backend/src/stats/stats.module.ts
+++ b/src/backend/src/stats/stats.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../database/database.module';
 import { StatsController } from './stats.controller';
 import { StatsService } from './stats.service';
+import { UsersModule } from '../users/users.module';
+import { RolesGuard } from '../auth/roles.guard';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, UsersModule],
   controllers: [StatsController],
-  providers: [StatsService],
+  providers: [StatsService, RolesGuard],
   exports: [StatsService],
 })
 export class StatsModule {}

--- a/src/backend/src/stats/stats.service.ts
+++ b/src/backend/src/stats/stats.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { count, sum, sql, gte, inArray, eq } from 'drizzle-orm';
+import { count, sum, sql, gte, eq } from 'drizzle-orm';
 import { DatabaseService } from '../database/database.service';
-import { users, events, tickets, payments } from '../db/schema';
+import { users, events, tickets } from '../db/schema';
 
 export interface DashboardStats {
   userCount: number;

--- a/src/backend/src/users/users.controller.ts
+++ b/src/backend/src/users/users.controller.ts
@@ -55,9 +55,14 @@ export class UsersController {
     const user = { ...body };
     if (user.isSystemAdmin !== undefined) {
       if (!user.password || typeof user.password !== 'string') {
-        throw new BadRequestException('Password is required to change admin role.');
+        throw new BadRequestException(
+          'Password is required to change admin role.',
+        );
       }
-      const valid = await this.usersService.verifyUserPassword(req.user.sub, user.password);
+      const valid = await this.usersService.verifyUserPassword(
+        req.user.sub,
+        user.password,
+      );
       if (!valid) {
         throw new UnauthorizedException('Invalid password.');
       }
@@ -71,10 +76,7 @@ export class UsersController {
 
   @Put(':id/roles')
   @Roles('Admin')
-  updateRoles(
-    @Param('id') id: string,
-    @Body() body: { roles?: string[] },
-  ) {
+  updateRoles(@Param('id') id: string, @Body() body: { roles?: string[] }) {
     const roles = Array.isArray(body.roles) ? body.roles : [];
     return this.usersService.replaceRoles(+id, roles);
   }

--- a/src/backend/src/users/users.controller.ts
+++ b/src/backend/src/users/users.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Post,
@@ -7,12 +8,15 @@ import {
   Body,
   Param,
   Req,
+  UnauthorizedException,
   UseGuards,
-  ForbiddenException,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import type { NewUser } from '../db/schema';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+
+type UpdateUserBody = Partial<NewUser> & { password?: string };
 
 @Controller('users')
 @UseGuards(JwtAuthGuard)
@@ -20,36 +24,68 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get()
+  @Roles('Admin')
   findAll() {
     return this.usersService.findAll();
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string, @Req() req: any) {
-    if (req.user?.sub !== +id) {
-      throw new ForbiddenException('Access denied.');
-    }
+  @Roles('Admin')
+  findOne(@Param('id') id: string) {
+    // Admin panel: any authenticated admin can view user profiles.
+    // Fine-grained per-user access control will be added later if needed.
     return this.usersService.findOneWithRoles(+id);
   }
 
   @Post()
+  @Roles('Admin')
   create(@Body() user: NewUser) {
     return this.usersService.create(user);
   }
 
   @Put(':id')
-  update(@Param('id') id: string, @Body() user: Partial<NewUser>, @Req() req: any) {
-    if (req.user?.sub !== +id) {
-      throw new ForbiddenException('Access denied.');
+  @Roles('Admin')
+  async update(
+    @Param('id') id: string,
+    @Body() body: UpdateUserBody,
+    @Req() req: { user?: { sub?: number } },
+  ) {
+    const user = { ...body };
+    if (user.isSystemAdmin !== undefined) {
+      if (!user.password || typeof user.password !== 'string') {
+        throw new BadRequestException('Password is required to change admin role.');
+      }
+      const currentUserId = req.user?.sub;
+      if (!currentUserId) {
+        throw new UnauthorizedException('Not authenticated.');
+      }
+      const valid = await this.usersService.verifyUserPassword(currentUserId, user.password);
+      if (!valid) {
+        throw new UnauthorizedException('Invalid password.');
+      }
+      delete (user as UpdateUserBody).password;
     }
-    return this.usersService.update(+id, user);
+    await this.usersService.update(+id, user);
+    const updated = await this.usersService.findOneWithRoles(+id);
+    if (!updated) throw new Error('User not found after update');
+    return updated;
+  }
+
+  @Put(':id/roles')
+  @Roles('Admin')
+  updateRoles(
+    @Param('id') id: string,
+    @Body() body: { roles?: string[] },
+  ) {
+    const roles = Array.isArray(body.roles) ? body.roles : [];
+    return this.usersService.replaceRoles(+id, roles);
   }
 
   @Delete(':id')
-  delete(@Param('id') id: string, @Req() req: any) {
-    if (req.user?.sub !== +id) {
-      throw new ForbiddenException('Access denied.');
-    }
+  @Roles('Admin')
+  delete(@Param('id') id: string) {
+    // Admin panel: any authenticated admin can delete user profiles.
+    // Fine-grained per-user access control will be added later if needed.
     return this.usersService.delete(+id);
   }
 }

--- a/src/backend/src/users/users.module.ts
+++ b/src/backend/src/users/users.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
+import { RolesGuard } from '../auth/roles.guard';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService],
-  exports: [UsersService],
+  providers: [UsersService, RolesGuard],
+  exports: [UsersService, RolesGuard],
 })
 export class UsersModule {}

--- a/src/backend/src/users/users.service.ts
+++ b/src/backend/src/users/users.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import bcrypt from 'bcryptjs';
 import { DatabaseService } from '../database/database.service';
 import { users, userRoles, roles } from '../db/schema';
 import type { NewUser } from '../db/schema';
@@ -56,6 +57,18 @@ export class UsersService {
     return result[0] ?? null;
   }
 
+  /** Verify password for the current user. Used for sensitive operations like role changes. */
+  async verifyUserPassword(userId: number, password: string): Promise<boolean> {
+    if (!password || typeof password !== 'string') return false;
+    const result = await this.dbService.db
+      .select({ passwordHash: users.passwordHash })
+      .from(users)
+      .where(eq(users.id, userId));
+    const row = result[0];
+    if (!row?.passwordHash) return false;
+    return bcrypt.compare(password, row.passwordHash);
+  }
+
   async findByEmailWithRoles(email: string) {
     const user = await this.findByEmail(email);
     if (!user) return null;
@@ -77,6 +90,44 @@ export class UsersService {
       .where(eq(users.id, id))
       .returning();
     return result[0];
+  }
+
+  /**
+   * Replace all non-admin roles for a user with the provided role names.
+   * This is used by the admin panel to assign a primary role (currently Member only).
+   */
+  async replaceRoles(id: number, roleNames: string[]) {
+    const db = this.dbService.db;
+
+    // Resolve role names to IDs.
+    const allRoles = await db.select().from(roles);
+    const targetRoleIds = allRoles
+      .filter((r) => roleNames.includes(r.name))
+      .map((r) => r.id);
+
+    // Validate that all requested roles exist.
+    const existingRoleNames = new Set(allRoles.map((r) => r.name));
+    const missingRoles = roleNames.filter((name) => !existingRoleNames.has(name));
+    if (missingRoles.length > 0) {
+      throw new BadRequestException(
+        `Role(s) not found: ${missingRoles.join(', ')}. Available roles: ${Array.from(existingRoleNames).join(', ')}`,
+      );
+    }
+
+    // Remove all existing role mappings for this user.
+    await db.delete(userRoles).where(eq(userRoles.userId, id));
+
+    // Insert the new mappings.
+    if (targetRoleIds.length > 0) {
+      await db.insert(userRoles).values(
+        targetRoleIds.map((roleId) => ({
+          userId: id,
+          roleId,
+        })),
+      );
+    }
+
+    return this.findOneWithRoles(id);
   }
 
   async delete(id: number) {

--- a/src/backend/src/users/users.service.ts
+++ b/src/backend/src/users/users.service.ts
@@ -13,7 +13,7 @@ export class UsersService {
     // Avoid leaking password hashes to clients.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { passwordHash, ...rest } = user;
-    return rest as Omit<T, 'passwordHash'>;
+    return rest;
   }
 
   async findAll() {
@@ -107,7 +107,9 @@ export class UsersService {
 
     // Validate that all requested roles exist.
     const existingRoleNames = new Set(allRoles.map((r) => r.name));
-    const missingRoles = roleNames.filter((name) => !existingRoleNames.has(name));
+    const missingRoles = roleNames.filter(
+      (name) => !existingRoleNames.has(name),
+    );
     if (missingRoles.length > 0) {
       throw new BadRequestException(
         `Role(s) not found: ${missingRoles.join(', ')}. Available roles: ${Array.from(existingRoleNames).join(', ')}`,

--- a/src/frontend/web-admin/app/_lib/auth.ts
+++ b/src/frontend/web-admin/app/_lib/auth.ts
@@ -1,0 +1,21 @@
+const TOKEN_COOKIE = "macsync_token";
+
+/** Read the JWT from the cookie (client-side only). */
+export function getToken(): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${TOKEN_COOKIE}=([^;]*)`)
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/** Persist a JWT in a cookie (7-day expiry, accessible to middleware). */
+export function setToken(token: string): void {
+  const maxAge = 7 * 24 * 60 * 60; // 7 days
+  document.cookie = `${TOKEN_COOKIE}=${encodeURIComponent(token)}; path=/; max-age=${maxAge}; SameSite=Lax`;
+}
+
+/** Remove the JWT cookie (used on logout). */
+export function clearToken(): void {
+  document.cookie = `${TOKEN_COOKIE}=; path=/; max-age=0`;
+}

--- a/src/frontend/web-admin/app/components/DashboardShell.tsx
+++ b/src/frontend/web-admin/app/components/DashboardShell.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { clearToken } from "../_lib/auth";
 
 const navItems = [
   { href: "/", label: "Dashboard" },
@@ -15,6 +16,17 @@ export default function DashboardShell({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  const router = useRouter();
+
+  // Don't render the shell on the login page
+  if (pathname === "/login") {
+    return <>{children}</>;
+  }
+
+  function handleLogout() {
+    clearToken();
+    router.push("/login");
+  }
 
   return (
     <div className="min-h-screen flex bg-app-gray">
@@ -55,7 +67,27 @@ export default function DashboardShell({
           })}
         </nav>
         <div className="p-3 border-t border-gray-100">
-          <p className="text-xs text-gray-500 px-3">Admin portal</p>
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+              />
+            </svg>
+            Sign out
+          </button>
         </div>
       </aside>
 

--- a/src/frontend/web-admin/app/login/page.tsx
+++ b/src/frontend/web-admin/app/login/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { login } from "../_lib/api";
+import { setToken } from "../_lib/auth";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { token, user } = await login(email, password);
+
+      const roles = user.roles ?? [];
+      const isAdmin = user.isSystemAdmin || roles.includes("Admin");
+
+      if (!isAdmin) {
+        setError("Access denied. Only system administrators can sign in.");
+        setLoading(false);
+        return;
+      }
+
+      setToken(token);
+      router.push("/");
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Login failed. Please try again.";
+      // Try to parse backend JSON error
+      try {
+        const parsed = JSON.parse(msg);
+        setError(parsed.message ?? msg);
+      } catch {
+        setError(msg);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-app-gray px-4">
+      <div className="w-full max-w-sm">
+        {/* Logo */}
+        <div className="flex flex-col items-center mb-8">
+          <div className="w-14 h-14 bg-maroon rounded-2xl flex items-center justify-center mb-4">
+            <span className="text-white text-2xl font-bold">M</span>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">MacSync Admin</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Sign in with your McMaster account
+          </p>
+        </div>
+
+        {/* Form card */}
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6 space-y-5"
+        >
+          {error && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              autoComplete="email"
+              placeholder="you@mcmaster.ca"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-maroon focus:ring-1 focus:ring-maroon outline-none transition-colors"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              autoComplete="current-password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-maroon focus:ring-1 focus:ring-maroon outline-none transition-colors"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-maroon hover:bg-maroon-dark text-white text-sm font-semibold py-2.5 transition-colors disabled:opacity-60"
+          >
+            {loading ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-gray-400 mt-6">
+          Only @mcmaster.ca accounts with admin privileges can access this
+          portal.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/web-admin/app/users/[id]/page.tsx
+++ b/src/frontend/web-admin/app/users/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import {
   getUser,
   getUserTickets,
+  getMe,
   updateUser,
   type Ticket,
   type User,
@@ -35,16 +36,27 @@ export default function UserProfilePage() {
   const [error, setError] = useState<string | null>(null);
   const [savingRole, setSavingRole] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [roleConfirmStep, setRoleConfirmStep] = useState<
+    null | "confirm" | "password"
+  >(null);
+  const [pendingRoleChange, setPendingRoleChange] = useState<boolean | null>(
+    null,
+  );
+  const [passwordInput, setPasswordInput] = useState("");
+  const [passwordError, setPasswordError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!Number.isFinite(userId)) return;
     async function load() {
       try {
         setError(null);
-        const [u, t] = await Promise.all([
+        const [me, u, t] = await Promise.all([
+          getMe(),
           getUser(userId),
           getUserTickets(userId),
         ]);
+        setCurrentUser(me);
         setUser(u);
         setTickets(t);
       } catch (e) {
@@ -61,17 +73,64 @@ export default function UserProfilePage() {
     [tickets],
   );
 
-  async function onToggleSystemAdmin(next: boolean) {
-    if (!user) return;
+  const currentRoles = currentUser?.roles ?? [];
+  const currentIsAdmin =
+    !!currentUser &&
+    (currentUser.isSystemAdmin || currentRoles.includes("Admin"));
+
+  function startRoleChange(next: boolean) {
+    setPendingRoleChange(next);
+    setRoleConfirmStep("confirm");
+    setPasswordInput("");
+    setPasswordError(null);
+  }
+
+  function cancelRoleChange() {
+    setRoleConfirmStep(null);
+    setPendingRoleChange(null);
+    setPasswordInput("");
+    setPasswordError(null);
+  }
+
+  async function submitRoleChange() {
+    if (!user || pendingRoleChange === null) return;
+    if (!passwordInput.trim()) {
+      setPasswordError("Please enter your password.");
+      return;
+    }
     try {
       setSavingRole(true);
-      const updated = await updateUser(user.id, { isSystemAdmin: next });
+      setPasswordError(null);
+      const updated = await updateUser(user.id, {
+        isSystemAdmin: pendingRoleChange,
+        password: passwordInput,
+      });
       setUser((prev) => (prev ? { ...prev, ...updated } : updated));
+      cancelRoleChange();
     } catch (e) {
-      alert(e instanceof Error ? e.message : "Failed to update user");
+      const raw = e instanceof Error ? e.message : "Unknown error";
+      let friendly = raw;
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed?.message === "Invalid password." || parsed?.statusCode === 401) {
+          friendly = "Password is incorrect. Please try again.";
+        } else if (typeof parsed?.message === "string") {
+          friendly = parsed.message;
+        }
+      } catch {
+        // Not JSON; use raw message unless it looks like a raw API response
+        if (raw.startsWith("{") && raw.includes("statusCode")) {
+          friendly = "Password is incorrect. Please try again.";
+        }
+      }
+      setPasswordError(friendly);
     } finally {
       setSavingRole(false);
     }
+  }
+
+  function onConfirmYes() {
+    setRoleConfirmStep("password");
   }
 
   if (loading) {
@@ -101,6 +160,100 @@ export default function UserProfilePage() {
 
   return (
     <div className="space-y-6">
+      {/* Role change confirmation modal */}
+      {roleConfirmStep && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => e.target === e.currentTarget && cancelRoleChange()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="role-confirm-title"
+        >
+          <div
+            className="bg-white rounded-xl shadow-xl max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {roleConfirmStep === "confirm" ? (
+              <>
+                <h2
+                  id="role-confirm-title"
+                  className="text-lg font-bold text-gray-900"
+                >
+                  Confirm admin role change
+                </h2>
+                <p className="mt-2 text-gray-600">
+                  Are you sure you want to do that?
+                </p>
+                <div className="mt-6 flex gap-3 justify-end">
+                  <button
+                    type="button"
+                    onClick={cancelRoleChange}
+                    className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onConfirmYes}
+                    className="px-4 py-2 text-sm font-medium text-white bg-maroon hover:bg-maroon-dark rounded-lg transition-colors"
+                  >
+                    Yes, continue
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h2
+                  id="role-confirm-title"
+                  className="text-lg font-bold text-gray-900"
+                >
+                  Enter your password
+                </h2>
+                <p className="mt-2 text-gray-600">
+                  Enter your password to confirm this change.
+                </p>
+                <input
+                  type="password"
+                  value={passwordInput}
+                  onChange={(e) => {
+                    setPasswordInput(e.target.value);
+                    setPasswordError(null);
+                  }}
+                  placeholder="Your password"
+                  className="mt-4 w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-maroon focus:border-maroon outline-none"
+                  autoFocus
+                  autoComplete="current-password"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") submitRoleChange();
+                    if (e.key === "Escape") cancelRoleChange();
+                  }}
+                />
+                {passwordError && (
+                  <p className="mt-2 text-sm text-red-600">{passwordError}</p>
+                )}
+                <div className="mt-6 flex gap-3 justify-end">
+                  <button
+                    type="button"
+                    onClick={cancelRoleChange}
+                    className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={submitRoleChange}
+                    disabled={savingRole}
+                    className="px-4 py-2 text-sm font-medium text-white bg-maroon hover:bg-maroon-dark rounded-lg transition-colors disabled:opacity-60"
+                  >
+                    {savingRole ? "Verifying…" : "Confirm"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
       <div className="flex items-start justify-between gap-6">
         <div>
           <Link
@@ -116,13 +269,12 @@ export default function UserProfilePage() {
         </div>
 
         <div className="flex flex-col items-end gap-2">
-          <div className="flex flex-wrap gap-2">
-            {user.isSystemAdmin && (
-              <span className="px-2 py-1 rounded-full bg-maroon/10 text-maroon text-xs font-bold">
-                SYSTEM_ADMIN
-              </span>
-            )}
-            {user.roles?.map((r) => (
+          <div className="flex flex-wrap gap-2 items-center">
+            <span className="text-xs text-gray-500 mr-1">Role:</span>
+            {(user.roles && user.roles.length > 0
+              ? user.roles
+              : ["Member"]
+            ).map((r) => (
               <span
                 key={r}
                 className="px-2 py-1 rounded-full bg-gray-100 text-gray-700 text-xs font-semibold"
@@ -130,18 +282,25 @@ export default function UserProfilePage() {
                 {r}
               </span>
             ))}
+            {user.isSystemAdmin && (
+              <span className="px-2 py-1 rounded-full bg-maroon/10 text-maroon text-xs font-bold">
+                SYSTEM_ADMIN
+              </span>
+            )}
           </div>
-          <button
-            type="button"
-            onClick={() => setShowAdvanced((v) => !v)}
-            className="text-sm font-medium text-maroon hover:text-maroon-dark hover:underline"
-          >
-            {showAdvanced ? "Hide advanced settings" : "Advanced settings"}
-          </button>
+          {currentIsAdmin && (
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((v) => !v)}
+              className="text-sm font-medium text-maroon hover:text-maroon-dark hover:underline"
+            >
+              {showAdvanced ? "Hide advanced settings" : "Advanced settings"}
+            </button>
+          )}
         </div>
       </div>
 
-      {showAdvanced && (
+      {showAdvanced && currentIsAdmin && (
         <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 space-y-5">
           <div>
             <h2 className="text-base font-bold text-gray-900">Advanced settings</h2>
@@ -160,7 +319,7 @@ export default function UserProfilePage() {
             </div>
             <button
               type="button"
-              onClick={() => onToggleSystemAdmin(!user.isSystemAdmin)}
+              onClick={() => startRoleChange(!user.isSystemAdmin)}
               disabled={savingRole}
               className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                 user.isSystemAdmin ? "bg-maroon" : "bg-gray-300"

--- a/src/frontend/web-admin/middleware.ts
+++ b/src/frontend/web-admin/middleware.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const PUBLIC_PATHS = ["/login"];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get("macsync_token")?.value;
+
+  const isPublic = PUBLIC_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`)
+  );
+
+  // No token and trying to access a protected page → redirect to /login
+  if (!token && !isPublic) {
+    const loginUrl = new URL("/login", request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Has token but visiting /login → redirect to dashboard
+  if (token && isPublic) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all paths except Next.js internals and static assets.
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/src/mobile/package-lock.json
+++ b/src/mobile/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "mobile",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "../mobile-components": {
+      "extraneous": true
+    }
+  }
+}


### PR DESCRIPTION
Backend:
- Add Roles decorator and RolesGuard for role-based access control
- Gate users, stats, and events endpoints by role (Admin/Member)
- Require password confirmation when changing a user's admin role
- Add verifyUserPassword and replaceRoles to UsersService
- Fix getUserTickets: allow self-access or Admin (keeps mobile app working)
- Update seed data: remove Guest role, use @mcmaster.ca emails, add passwordHash
- Extend CORS with methods used by admin panel

Frontend web-admin:
- Add login page, auth middleware, and token handling
- Add JWT to API requests and logout in DashboardShell
- Gate advanced settings to admins; show confirm + password for role changes
- Replace raw JSON with friendly "Password is incorrect" message on error
- Add getMe, updateUserRoles, login to API client