### PR TITLE
[SL-264] Refund Request Service w/ E2E Tests

### DIFF
--- a/src/backend/src/app.module.ts
+++ b/src/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { PaymentsModule } from './payments/payments.module';
 import { StatsModule } from './stats/stats.module';
+import { RefundRequestsModule } from './refund-requests/refund-requests.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { StatsModule } from './stats/stats.module';
     PaymentsModule,
     AuthModule,
     StatsModule,
+    RefundRequestsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/backend/src/db/schema.ts
+++ b/src/backend/src/db/schema.ts
@@ -211,3 +211,34 @@ export const seatReservations = pgTable('seat_reservations', {
 
 export type SeatReservation = typeof seatReservations.$inferSelect;
 export type NewSeatReservation = typeof seatReservations.$inferInsert;
+
+// ------------------- REFUND REQUESTS -------------------
+export const refundRequests = pgTable('refund_requests', {
+  id: serial('id').primaryKey(),
+  ticketId: integer('ticket_id').references(() => tickets.id, {
+    onDelete: 'set null',
+  }),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  eventId: integer('event_id')
+    .notNull()
+    .references(() => events.id, { onDelete: 'cascade' }),
+  paymentId: integer('payment_id').references(() => payments.id, {
+    onDelete: 'set null',
+  }),
+  reason: varchar('reason', { length: 500 }),
+  status: varchar('status', { length: 50 })
+    .notNull()
+    .default('pending'), // 'pending', 'approved', 'denied'
+  adminResponse: varchar('admin_response', { length: 500 }),
+  processedBy: integer('processed_by').references(() => users.id, {
+    onDelete: 'set null',
+  }), // admin who processed
+  processedAt: timestamp('processed_at'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+});
+
+export type RefundRequest = typeof refundRequests.$inferSelect;
+export type NewRefundRequest = typeof refundRequests.$inferInsert;

--- a/src/backend/src/events/events.service.ts
+++ b/src/backend/src/events/events.service.ts
@@ -8,6 +8,7 @@ import {
   tableSeats,
   busSeats,
   seatReservations,
+  refundRequests,
 } from '../db/schema';
 import type { NewEvent } from '../db/schema';
 import { eq, sql, and, asc } from 'drizzle-orm';
@@ -282,12 +283,39 @@ export class EventsService {
         eventLocation: events.location,
         eventPrice: events.price,
         eventImageUrl: events.imageUrl,
+        refundRequestId: refundRequests.id,
+        refundRequestStatus: refundRequests.status,
+        refundRequestAdminResponse: refundRequests.adminResponse,
+        refundRequestCreatedAt: refundRequests.createdAt,
       })
       .from(tickets)
       .innerJoin(events, eq(tickets.eventId, events.id))
+      .leftJoin(
+        refundRequests,
+        and(
+          eq(refundRequests.ticketId, tickets.id),
+          eq(refundRequests.status, 'pending'), // Only show pending requests
+        ),
+      )
       .where(eq(tickets.userId, userId));
 
-    return rows;
+    // Transform to include refundRequest as nested object
+    return rows.map((row) => ({
+      ...row,
+      refundRequest: row.refundRequestId
+        ? {
+            id: row.refundRequestId,
+            status: row.refundRequestStatus,
+            adminResponse: row.refundRequestAdminResponse,
+            createdAt: row.refundRequestCreatedAt,
+          }
+        : null,
+      // Remove the flattened fields
+      refundRequestId: undefined,
+      refundRequestStatus: undefined,
+      refundRequestAdminResponse: undefined,
+      refundRequestCreatedAt: undefined,
+    }));
   }
 
   /** Create Stripe Checkout Session for event signup; user is only signed up after payment (via webhook). */

--- a/src/backend/src/main.ts
+++ b/src/backend/src/main.ts
@@ -49,6 +49,7 @@ async function bootstrap() {
     origin: true, // Allow all origins (dev)
     credentials: true,
     methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
   await app.listen(process.env.PORT ?? 3000, '0.0.0.0');

--- a/src/backend/src/refund-requests/refund-requests.controller.ts
+++ b/src/backend/src/refund-requests/refund-requests.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Put,
+  Body,
+  Param,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RefundRequestsService } from './refund-requests.service';
+
+interface RequestWithUser extends Request {
+  user: {
+    sub: number;
+    email: string;
+  };
+}
+
+@Controller('refund-requests')
+@UseGuards(JwtAuthGuard)
+export class RefundRequestsController {
+  constructor(
+    private readonly refundRequestsService: RefundRequestsService,
+  ) {}
+
+  @Post()
+  createRefundRequest(
+    @Req() req: RequestWithUser,
+    @Body() body: { ticketId: number; reason?: string },
+  ) {
+    return this.refundRequestsService.createRefundRequest(
+      req.user.sub,
+      body.ticketId,
+      body.reason,
+    );
+  }
+
+  @Get()
+  getAllRefundRequests(@Req() req: RequestWithUser) {
+    return this.refundRequestsService.getAllRefundRequests(req.user.sub);
+  }
+
+  @Get('my-requests')
+  getUserRefundRequests(@Req() req: RequestWithUser) {
+    return this.refundRequestsService.getUserRefundRequests(req.user.sub);
+  }
+
+  @Put(':id/approve')
+  approveRefundRequest(
+    @Param('id') id: string,
+    @Req() req: RequestWithUser,
+    @Body() body: { adminResponse?: string },
+  ) {
+    return this.refundRequestsService.approveRefundRequest(
+      +id,
+      req.user.sub,
+      body.adminResponse,
+    );
+  }
+
+  @Put(':id/deny')
+  denyRefundRequest(
+    @Param('id') id: string,
+    @Req() req: RequestWithUser,
+    @Body() body: { adminResponse?: string },
+  ) {
+    return this.refundRequestsService.denyRefundRequest(
+      +id,
+      req.user.sub,
+      body.adminResponse,
+    );
+  }
+}

--- a/src/backend/src/refund-requests/refund-requests.module.ts
+++ b/src/backend/src/refund-requests/refund-requests.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { RefundRequestsController } from './refund-requests.controller';
+import { RefundRequestsService } from './refund-requests.service';
+import { DatabaseModule } from '../database/database.module';
+import { PaymentsModule } from '../payments/payments.module';
+
+@Module({
+  imports: [DatabaseModule, PaymentsModule],
+  controllers: [RefundRequestsController],
+  providers: [RefundRequestsService],
+  exports: [RefundRequestsService],
+})
+export class RefundRequestsModule {}

--- a/src/backend/src/refund-requests/refund-requests.service.ts
+++ b/src/backend/src/refund-requests/refund-requests.service.ts
@@ -1,0 +1,262 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { PaymentsService } from '../payments/payments.service';
+import { refundRequests, users, tickets, events, payments } from '../db/schema';
+import { eq, and, desc } from 'drizzle-orm';
+
+@Injectable()
+export class RefundRequestsService {
+  constructor(
+    private readonly dbService: DatabaseService,
+    private readonly paymentsService: PaymentsService,
+  ) {}
+
+  /**
+   * User requests a refund for their ticket
+   */
+  async createRefundRequest(
+    userId: number,
+    ticketId: number,
+    reason?: string,
+  ): Promise<{ success?: boolean; error?: string; requestId?: number }> {
+    // Verify ticket belongs to user
+    const ticketRows = await this.dbService.db
+      .select()
+      .from(tickets)
+      .where(and(eq(tickets.id, ticketId), eq(tickets.userId, userId)))
+      .limit(1);
+
+    if (ticketRows.length === 0) {
+      return { error: 'Ticket not found or does not belong to you' };
+    }
+
+    const ticket = ticketRows[0];
+
+    // Check if refund request already exists
+    const existingRequests = await this.dbService.db
+      .select()
+      .from(refundRequests)
+      .where(
+        and(
+          eq(refundRequests.ticketId, ticketId),
+          eq(refundRequests.status, 'pending'),
+        ),
+      )
+      .limit(1);
+
+    if (existingRequests.length > 0) {
+      return { error: 'A refund request is already pending for this ticket' };
+    }
+
+    // Find associated payment
+    const paymentRows = await this.dbService.db
+      .select()
+      .from(payments)
+      .where(eq(payments.ticketId, ticketId))
+      .limit(1);
+
+    const payment = paymentRows[0] || null;
+
+    // Create refund request
+    const result = await this.dbService.db
+      .insert(refundRequests)
+      .values({
+        ticketId,
+        userId,
+        eventId: ticket.eventId,
+        paymentId: payment?.id,
+        reason: reason || null,
+        status: 'pending',
+      })
+      .returning();
+
+    return { success: true, requestId: result[0].id };
+  }
+
+  /**
+   * Get all refund requests (admin only)
+   */
+  async getAllRefundRequests(adminUserId: number) {
+    // Check if user is admin
+    const adminRows = await this.dbService.db
+      .select()
+      .from(users)
+      .where(eq(users.id, adminUserId))
+      .limit(1);
+
+    if (!adminRows[0] || !adminRows[0].isSystemAdmin) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    // Get all refund requests with user, event, and ticket info
+    const requests = await this.dbService.db
+      .select({
+        id: refundRequests.id,
+        ticketId: refundRequests.ticketId,
+        userId: refundRequests.userId,
+        eventId: refundRequests.eventId,
+        paymentId: refundRequests.paymentId,
+        reason: refundRequests.reason,
+        status: refundRequests.status,
+        adminResponse: refundRequests.adminResponse,
+        processedBy: refundRequests.processedBy,
+        processedAt: refundRequests.processedAt,
+        createdAt: refundRequests.createdAt,
+        userName: users.name,
+        userEmail: users.email,
+        eventName: events.name,
+        eventDate: events.date,
+      })
+      .from(refundRequests)
+      .leftJoin(users, eq(refundRequests.userId, users.id))
+      .leftJoin(events, eq(refundRequests.eventId, events.id))
+      .orderBy(desc(refundRequests.createdAt));
+
+    return requests;
+  }
+
+  /**
+   * Get refund requests for a specific user
+   */
+  async getUserRefundRequests(userId: number) {
+    const requests = await this.dbService.db
+      .select({
+        id: refundRequests.id,
+        ticketId: refundRequests.ticketId,
+        eventId: refundRequests.eventId,
+        reason: refundRequests.reason,
+        status: refundRequests.status,
+        adminResponse: refundRequests.adminResponse,
+        processedAt: refundRequests.processedAt,
+        createdAt: refundRequests.createdAt,
+        eventName: events.name,
+      })
+      .from(refundRequests)
+      .leftJoin(events, eq(refundRequests.eventId, events.id))
+      .where(eq(refundRequests.userId, userId))
+      .orderBy(desc(refundRequests.createdAt));
+
+    return requests;
+  }
+
+  /**
+   * Approve refund request and process refund via Stripe (admin only)
+   */
+  async approveRefundRequest(
+    requestId: number,
+    adminUserId: number,
+    adminResponse?: string,
+  ): Promise<{ success?: boolean; error?: string }> {
+    // Check if user is admin
+    const adminRows = await this.dbService.db
+      .select()
+      .from(users)
+      .where(eq(users.id, adminUserId))
+      .limit(1);
+
+    if (!adminRows[0] || !adminRows[0].isSystemAdmin) {
+      return { error: 'Admin access required' };
+    }
+
+    // Get refund request
+    const requestRows = await this.dbService.db
+      .select()
+      .from(refundRequests)
+      .where(eq(refundRequests.id, requestId))
+      .limit(1);
+
+    if (requestRows.length === 0) {
+      return { error: 'Refund request not found' };
+    }
+
+    const request = requestRows[0];
+
+    if (request.status !== 'pending') {
+      return { error: 'Refund request has already been processed' };
+    }
+
+    // Process refund via PaymentsService if payment exists
+    if (request.paymentId) {
+      const refundResult = await this.paymentsService.refundPayment(
+        request.paymentId,
+        adminUserId,
+      );
+
+      if (refundResult.error) {
+        return { error: `Refund failed: ${refundResult.error}` };
+      }
+    }
+
+    // Update refund request status
+    await this.dbService.db
+      .update(refundRequests)
+      .set({
+        status: 'approved',
+        adminResponse: adminResponse || null,
+        processedBy: adminUserId,
+        processedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(refundRequests.id, requestId));
+
+    // Delete the ticket if it exists
+    if (request.ticketId) {
+      await this.dbService.db
+        .delete(tickets)
+        .where(eq(tickets.id, request.ticketId));
+    }
+
+    return { success: true };
+  }
+
+  /**
+   * Deny refund request (admin only)
+   */
+  async denyRefundRequest(
+    requestId: number,
+    adminUserId: number,
+    adminResponse?: string,
+  ): Promise<{ success?: boolean; error?: string }> {
+    // Check if user is admin
+    const adminRows = await this.dbService.db
+      .select()
+      .from(users)
+      .where(eq(users.id, adminUserId))
+      .limit(1);
+
+    if (!adminRows[0] || !adminRows[0].isSystemAdmin) {
+      return { error: 'Admin access required' };
+    }
+
+    // Get refund request
+    const requestRows = await this.dbService.db
+      .select()
+      .from(refundRequests)
+      .where(eq(refundRequests.id, requestId))
+      .limit(1);
+
+    if (requestRows.length === 0) {
+      return { error: 'Refund request not found' };
+    }
+
+    const request = requestRows[0];
+
+    if (request.status !== 'pending') {
+      return { error: 'Refund request has already been processed' };
+    }
+
+    // Update refund request status
+    await this.dbService.db
+      .update(refundRequests)
+      .set({
+        status: 'denied',
+        adminResponse: adminResponse || 'Refund request denied',
+        processedBy: adminUserId,
+        processedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(refundRequests.id, requestId));
+
+    return { success: true };
+  }
+}

--- a/src/frontend/mobile/app/(tabs)/_layout.tsx
+++ b/src/frontend/mobile/app/(tabs)/_layout.tsx
@@ -51,6 +51,7 @@ function HeaderLeft() {
 export default function TabLayout() {
   const insets = useSafeAreaInsets();
   const bottomPadding = Math.max(insets.bottom, 8);
+  const { isAdmin } = useAuth();
 
   return (
     <Tabs
@@ -100,6 +101,16 @@ export default function TabLayout() {
           title: "Profile",
           tabBarIcon: ({ color }) => (
             <Text style={{ fontSize: 20, color }}>👤</Text>
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="admin"
+        options={{
+          title: "Admin",
+          href: isAdmin ? "/(tabs)/admin" : null,
+          tabBarIcon: ({ color }) => (
+            <Text style={{ fontSize: 20, color }}>⚙️</Text>
           ),
         }}
       />

--- a/src/frontend/mobile/app/(tabs)/admin.tsx
+++ b/src/frontend/mobile/app/(tabs)/admin.tsx
@@ -1,0 +1,71 @@
+import { View, Text, ScrollView, Pressable } from "react-native";
+import { useRouter } from "expo-router";
+import { useAuth } from "../_context/AuthContext";
+import { useEffect } from "react";
+
+export default function AdminScreen() {
+  const router = useRouter();
+  const { isAdmin } = useAuth();
+
+  useEffect(() => {
+    if (!isAdmin) {
+      router.replace("/(tabs)");
+    }
+  }, [isAdmin, router]);
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  return (
+    <View className="flex-1 bg-[#F5F5F7]">
+      <ScrollView className="flex-1" contentContainerClassName="px-4 py-6">
+        <Text className="text-2xl font-bold text-gray-900 mb-2">
+          Admin Dashboard
+        </Text>
+        <Text className="text-sm text-gray-600 mb-6">
+          Manage events, refunds, and view analytics
+        </Text>
+
+        {/* Admin Features Grid */}
+        <View className="gap-4">
+          {/* Refund Requests */}
+          <Pressable
+            onPress={() => router.push("/refund-requests")}
+            className="bg-white rounded-2xl p-6 border border-gray-100 shadow-sm active:bg-gray-50"
+          >
+            <View className="flex-row items-start justify-between mb-3">
+              <View className="w-12 h-12 bg-yellow-100 rounded-xl items-center justify-center">
+                <Text className="text-2xl">💰</Text>
+              </View>
+            </View>
+            <Text className="text-lg font-bold text-gray-900 mb-1">
+              Refund Requests
+            </Text>
+            <Text className="text-sm text-gray-600">
+              Review and process pending refund requests
+            </Text>
+          </Pressable>
+
+          {/* QR Scanner - Coming Soon */}
+          <View className="bg-white rounded-2xl p-6 border border-gray-100 shadow-sm opacity-60">
+            <View className="flex-row items-start justify-between mb-3">
+              <View className="w-12 h-12 bg-blue-100 rounded-xl items-center justify-center">
+                <Text className="text-2xl">📷</Text>
+              </View>
+              <View className="bg-gray-400 px-2 py-1 rounded-full">
+                <Text className="text-xs font-bold text-white">Soon</Text>
+              </View>
+            </View>
+            <Text className="text-lg font-bold text-gray-900 mb-1">
+              QR Code Scanner
+            </Text>
+            <Text className="text-sm text-gray-600">
+              Scan tickets at event entrance
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/src/frontend/mobile/app/(tabs)/index.tsx
+++ b/src/frontend/mobile/app/(tabs)/index.tsx
@@ -142,31 +142,11 @@ function EventCard({
 
         {/* Action button */}
         {isSignedUp ? (
-          event.price === 0 ? (
-            <Pressable
-              onPress={() => onCancel(event.id)}
-              className="w-full py-3 rounded-xl border border-red-200 bg-red-50 active:bg-red-100"
-            >
-              <Text className="text-center text-sm font-semibold text-red-600">
-                Cancel Sign-Up
-              </Text>
-            </Pressable>
-          ) : (
-            <Pressable
-              onPress={() => {
-                if (Platform.OS === 'web') {
-                  alert('Refund request feature coming soon');
-                } else {
-                  Alert.alert('Coming Soon', 'Refund request feature will be available soon');
-                }
-              }}
-              className="w-full py-3 rounded-xl border border-yellow-200 bg-yellow-50 active:bg-yellow-100"
-            >
-              <Text className="text-center text-sm font-semibold text-yellow-700">
-                Request Refund
-              </Text>
-            </Pressable>
-          )
+          <View className="w-full py-3 rounded-xl border border-green-200 bg-green-50">
+            <Text className="text-center text-sm font-semibold text-green-700">
+              ✓ Signed Up
+            </Text>
+          </View>
         ) : (
           <Pressable
             onPress={() => onSignUp(event.id)}

--- a/src/frontend/mobile/app/(tabs)/my-tickets.tsx
+++ b/src/frontend/mobile/app/(tabs)/my-tickets.tsx
@@ -201,6 +201,17 @@ export default function MyTickets() {
 
                   {/* Content */}
                   <View className="flex-1 p-4">
+                    {/* Refund Status Badge */}
+                    {ticket.refundRequest && ticket.refundRequest.status === 'pending' && (
+                      <View className="mb-2">
+                        <View className="bg-yellow-100 px-3 py-1.5 rounded-lg self-start">
+                          <Text className="text-xs font-bold text-yellow-800">
+                            ⏳ Refund Pending
+                          </Text>
+                        </View>
+                      </View>
+                    )}
+
                     <View className="flex-row items-start justify-between mb-2">
                       <View className="flex-1">
                         <Text className="text-base font-bold text-gray-900">
@@ -209,37 +220,7 @@ export default function MyTickets() {
                         <Text className="text-maroon text-sm font-semibold mt-1">
                           View Ticket →
                         </Text>
-                      </View>
-                      {ticket.eventPrice === 0 ? (
-                        <Pressable
-                          onPress={(e) => {
-                            e.stopPropagation();
-                            handleCancel(ticket.eventId);
-                          }}
-                          className="px-3 py-1.5 border border-red-200 rounded-lg bg-red-50 active:bg-red-100"
-                        >
-                          <Text className="text-xs font-semibold text-red-600">
-                            Cancel
-                          </Text>
-                        </Pressable>
-                      ) : (
-                        <Pressable
-                          onPress={(e) => {
-                            e.stopPropagation();
-                            // TODO: Implement refund request
-                            if (Platform.OS === 'web') {
-                              alert('Refund request feature coming soon');
-                            } else {
-                              Alert.alert('Coming Soon', 'Refund request feature will be available soon');
-                            }
-                          }}
-                          className="px-3 py-1.5 border border-yellow-200 rounded-lg bg-yellow-50 active:bg-yellow-100"
-                        >
-                          <Text className="text-xs font-semibold text-yellow-700">
-                            Request Refund
-                          </Text>
-                        </Pressable>
-                      )}
+                      </View> 
                     </View>
 
                     <View className="gap-1">

--- a/src/frontend/mobile/app/(tabs)/profile.tsx
+++ b/src/frontend/mobile/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   Alert,
 } from "react-native";
 import { useRouter } from "expo-router";
+import { useFocusEffect } from "@react-navigation/native";
 import { updateUser, getMyRefundRequests, type RefundRequest } from "../_lib/api";
 import { useAuth } from "../_context/AuthContext";
 
@@ -40,6 +41,7 @@ export default function ProfileScreen() {
   }, [user]);
 
   const loadRefundedTickets = async () => {
+    setLoadingRefunds(true);
     try {
       const refunds = await getMyRefundRequests();
       // Only show approved refunds (tickets that were actually refunded)
@@ -50,6 +52,15 @@ export default function ProfileScreen() {
       setLoadingRefunds(false);
     }
   };
+
+  // Reload refunded tickets whenever the profile screen comes into focus
+  useFocusEffect(
+    useCallback(() => {
+      if (user) {
+        void loadRefundedTickets();
+      }
+    }, [user]),
+  );
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {

--- a/src/frontend/mobile/app/(tabs)/profile.tsx
+++ b/src/frontend/mobile/app/(tabs)/profile.tsx
@@ -8,13 +8,17 @@ import {
   ActivityIndicator,
   Alert,
 } from "react-native";
-import { updateUser } from "../_lib/api";
+import { useRouter } from "expo-router";
+import { updateUser, getMyRefundRequests, type RefundRequest } from "../_lib/api";
 import { useAuth } from "../_context/AuthContext";
 
 export default function ProfileScreen() {
   const { user, isAdmin, status, refreshUser } = useAuth();
+  const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [refundedTickets, setRefundedTickets] = useState<RefundRequest[]>([]);
+  const [loadingRefunds, setLoadingRefunds] = useState(true);
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -31,8 +35,29 @@ export default function ProfileScreen() {
         program: user.program || "",
       });
       setEditing(false);
+      loadRefundedTickets();
     }
   }, [user]);
+
+  const loadRefundedTickets = async () => {
+    try {
+      const refunds = await getMyRefundRequests();
+      // Only show approved refunds (tickets that were actually refunded)
+      setRefundedTickets(refunds.filter(r => r.status === 'approved'));
+    } catch (err) {
+      console.error("Failed to load refunded tickets:", err);
+    } finally {
+      setLoadingRefunds(false);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
 
   const handleSave = async () => {
     if (!user) return;
@@ -236,6 +261,80 @@ export default function ProfileScreen() {
               )}
             </View>
           </View>
+        </View>
+
+        {/* Refunded Tickets Section */}
+        <View className="mt-6">
+          <View className="flex-row items-center justify-between mb-3">
+            <Text className="text-lg font-bold text-gray-900">
+              Refunded Tickets
+            </Text>
+            {refundedTickets.length > 0 && (
+              <View className="bg-gray-200 px-2 py-1 rounded-full">
+                <Text className="text-xs font-bold text-gray-700">
+                  {refundedTickets.length}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          {loadingRefunds ? (
+            <View className="bg-white rounded-2xl p-8 items-center border border-gray-100">
+              <ActivityIndicator size="small" color="#7A1F3E" />
+            </View>
+          ) : refundedTickets.length === 0 ? (
+            <View className="bg-white rounded-2xl p-8 items-center border border-gray-100">
+              <Text className="text-4xl mb-3">🎫</Text>
+              <Text className="text-base font-medium text-gray-900 mb-1">
+                No Refunded Tickets
+              </Text>
+              <Text className="text-sm text-gray-500 text-center">
+                You haven't had any tickets refunded yet
+              </Text>
+            </View>
+          ) : (
+            <View className="gap-3">
+              {refundedTickets.map((refund) => (
+                <View
+                  key={refund.id}
+                  className="bg-white rounded-2xl p-4 border border-gray-100 shadow-sm"
+                >
+                  <View className="flex-row items-start justify-between mb-2">
+                    <View className="flex-1">
+                      <Text className="text-base font-bold text-gray-900 mb-1">
+                        {refund.eventName}
+                      </Text>
+                      {refund.eventDate && (
+                        <Text className="text-sm text-gray-600">
+                          {formatDate(refund.eventDate)}
+                        </Text>
+                      )}
+                    </View>
+                    <View className="bg-green-100 px-2 py-1 rounded-lg">
+                      <Text className="text-xs font-bold text-green-800">
+                        REFUNDED
+                      </Text>
+                    </View>
+                  </View>
+
+                  {refund.adminResponse && (
+                    <View className="mt-3 bg-gray-50 rounded-lg p-3">
+                      <Text className="text-xs text-gray-500 mb-1">
+                        Admin Message:
+                      </Text>
+                      <Text className="text-sm text-gray-700">
+                        {refund.adminResponse}
+                      </Text>
+                    </View>
+                  )}
+
+                  <Text className="text-xs text-gray-400 mt-2">
+                    Refunded on {refund.processedAt && formatDate(refund.processedAt)}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          )}
         </View>
       </ScrollView>
     </View>

--- a/src/frontend/mobile/app/_lib/api.ts
+++ b/src/frontend/mobile/app/_lib/api.ts
@@ -224,6 +224,12 @@ export interface Ticket {
   eventLocation: string | null;
   eventPrice: number;
   eventImageUrl: string | null;
+  refundRequest?: {
+    id: number;
+    status: 'pending' | 'approved' | 'denied';
+    adminResponse: string | null;
+    createdAt: string;
+  } | null;
 }
 
 export function getUserTickets(userId: number): Promise<Ticket[]> {
@@ -276,5 +282,62 @@ export function cancelSignup(
   return apiFetch(`/events/${eventId}/cancel`, {
     method: 'POST',
     body: JSON.stringify({}),
+  });
+}
+
+// ---------- Refund Requests ----------
+export interface RefundRequest {
+  id: number;
+  ticketId: number | null;
+  userId: number;
+  eventId: number;
+  paymentId: number | null;
+  reason: string | null;
+  status: 'pending' | 'approved' | 'denied';
+  adminResponse: string | null;
+  processedBy: number | null;
+  processedAt: string | null;
+  createdAt: string;
+  userName?: string;
+  userEmail?: string;
+  eventName?: string;
+  eventDate?: string;
+}
+
+export function createRefundRequest(
+  ticketId: number,
+  reason?: string,
+): Promise<{ success?: boolean; error?: string; requestId?: number }> {
+  return apiFetch('/refund-requests', {
+    method: 'POST',
+    body: JSON.stringify({ ticketId, reason }),
+  });
+}
+
+export function getAllRefundRequests(): Promise<RefundRequest[]> {
+  return apiFetch('/refund-requests');
+}
+
+export function getMyRefundRequests(): Promise<RefundRequest[]> {
+  return apiFetch('/refund-requests/my-requests');
+}
+
+export function approveRefundRequest(
+  requestId: number,
+  adminResponse?: string,
+): Promise<{ success?: boolean; error?: string }> {
+  return apiFetch(`/refund-requests/${requestId}/approve`, {
+    method: 'PUT',
+    body: JSON.stringify({ adminResponse }),
+  });
+}
+
+export function denyRefundRequest(
+  requestId: number,
+  adminResponse?: string,
+): Promise<{ success?: boolean; error?: string }> {
+  return apiFetch(`/refund-requests/${requestId}/deny`, {
+    method: 'PUT',
+    body: JSON.stringify({ adminResponse }),
   });
 }

--- a/src/frontend/mobile/app/refund-requests.tsx
+++ b/src/frontend/mobile/app/refund-requests.tsx
@@ -1,0 +1,365 @@
+import { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  ActivityIndicator,
+  TextInput,
+  Modal,
+  Alert,
+  Keyboard,
+  TouchableWithoutFeedback,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAuth } from "./_context/AuthContext";
+import {
+  getAllRefundRequests,
+  approveRefundRequest,
+  denyRefundRequest,
+  type RefundRequest,
+} from "./_lib/api";
+
+export default function RefundRequestsScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { isAdmin } = useAuth();
+  const [requests, setRequests] = useState<RefundRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedRequest, setSelectedRequest] = useState<RefundRequest | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [modalType, setModalType] = useState<"approve" | "deny">("approve");
+  const [adminResponse, setAdminResponse] = useState("");
+  const [processing, setProcessing] = useState(false);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      router.replace("/(tabs)");
+      return;
+    }
+    loadRequests();
+  }, [isAdmin, router]);
+
+  const loadRequests = async () => {
+    try {
+      const data = await getAllRefundRequests();
+      setRequests(data);
+    } catch (err) {
+      console.error("Failed to load refund requests:", err);
+      Alert.alert("Error", "Failed to load refund requests");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAction = async () => {
+    if (!selectedRequest) return;
+
+    // Validate required fields for both approve and deny
+    if (!adminResponse.trim()) {
+      Alert.alert(
+        "Required", 
+        `Please provide a ${modalType === "approve" ? "confirmation message" : "reason"} for ${modalType === "approve" ? "approving" : "denying"} this refund request.`
+      );
+      return;
+    }
+
+    setProcessing(true);
+    try {
+      const action = modalType === "approve" ? approveRefundRequest : denyRefundRequest;
+      const result = await action(selectedRequest.id, adminResponse.trim() || undefined);
+
+      if (result.error) {
+        Alert.alert("Error", result.error);
+      } else {
+        // Reload requests before showing success message
+        await loadRequests();
+        
+        Alert.alert(
+          "Success",
+          `Refund request ${modalType === "approve" ? "approved" : "denied"} successfully`
+        );
+        setShowModal(false);
+        setSelectedRequest(null);
+        setAdminResponse("");
+      }
+    } catch (err: any) {
+      console.error("Action error:", err);
+      Alert.alert("Error", err?.message || `Failed to ${modalType} refund request`);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const openModal = (request: RefundRequest, type: "approve" | "deny") => {
+    setSelectedRequest(request);
+    setModalType(type);
+    setShowModal(true);
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  };
+
+  const formatPrice = (price: number) => {
+    return `$${(price / 100).toFixed(2)}`;
+  };
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  if (loading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-[#F5F5F7]">
+        <ActivityIndicator size="large" color="#7A1F3E" />
+      </View>
+    );
+  }
+
+  const pendingRequests = requests.filter((r) => r.status === "pending");
+  const processedRequests = requests
+    .filter((r) => r.status !== "pending")
+    .sort((a, b) => {
+      // Sort by processedAt, most recent first
+      const aTime = a.processedAt ? new Date(a.processedAt).getTime() : 0;
+      const bTime = b.processedAt ? new Date(b.processedAt).getTime() : 0;
+      return bTime - aTime;
+    });
+
+  return (
+    <View className="flex-1 bg-[#F5F5F7]">
+      {/* Header */}
+      <View
+        className="bg-white border-b border-gray-200 px-4 pb-4"
+        style={{ paddingTop: Math.max(insets.top, 16) + 8 }}
+      >
+        <Pressable onPress={() => router.back()}>
+          <Text className="text-base text-maroon font-medium">
+            ← Back to Admin
+          </Text>
+        </Pressable>
+      </View>
+
+      <ScrollView className="flex-1" contentContainerClassName="px-4 py-6">
+        <Text className="text-2xl font-bold text-gray-900 mb-2">
+          Refund Requests
+        </Text>
+        <Text className="text-sm text-gray-600 mb-6">
+          Review and process refund requests from users
+        </Text>
+
+        {/* Pending Requests */}
+        {pendingRequests.length > 0 && (
+          <>
+            <Text className="text-lg font-bold text-gray-900 mb-3">
+              Pending ({pendingRequests.length})
+            </Text>
+            <View className="gap-4 mb-6">
+              {pendingRequests.map((request) => (
+                <View
+                  key={request.id}
+                  className="bg-white rounded-2xl p-4 border border-yellow-300 shadow-sm"
+                >
+                  <View className="flex-row items-start justify-between mb-3">
+                    <View className="flex-1">
+                      <Text className="text-lg font-bold text-gray-900 mb-1">
+                        {request.eventName}
+                      </Text>
+                      <Text className="text-sm text-gray-600">
+                        {request.userName} • {request.userEmail}
+                      </Text>
+                    </View>
+                    <View className="bg-yellow-100 px-2 py-1 rounded-lg">
+                      <Text className="text-xs font-bold text-yellow-800">
+                        PENDING
+                      </Text>
+                    </View>
+                  </View>
+
+                  {request.reason && (
+                    <View className="bg-gray-50 rounded-lg p-3 mb-3">
+                      <Text className="text-xs text-gray-500 mb-1">Reason:</Text>
+                      <Text className="text-sm text-gray-700">{request.reason}</Text>
+                    </View>
+                  )}
+
+                  <Text className="text-xs text-gray-400 mb-3">
+                    Requested {formatDate(request.createdAt)}
+                  </Text>
+
+                  <View className="flex-row gap-2">
+                    <Pressable
+                      onPress={() => openModal(request, "approve")}
+                      className="flex-1 bg-green-500 active:bg-green-600 rounded-xl p-3 items-center"
+                    >
+                      <Text className="text-sm font-bold text-white">✓ Approve</Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => openModal(request, "deny")}
+                      className="flex-1 bg-red-500 active:bg-red-600 rounded-xl p-3 items-center"
+                    >
+                      <Text className="text-sm font-bold text-white">✗ Deny</Text>
+                    </Pressable>
+                  </View>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+
+        {pendingRequests.length === 0 && (
+          <View className="bg-white rounded-2xl p-8 items-center mb-6">
+            
+            <Text className="text-base font-bold text-gray-900 mb-1">
+              All caught up!
+            </Text>
+            <Text className="text-sm text-gray-600 text-center">
+              No pending refund requests at the moment
+            </Text>
+          </View>
+        )}
+
+        {/* Processed Requests */}
+        {processedRequests.length > 0 && (
+          <>
+            <Text className="text-lg font-bold text-gray-900 mb-3">
+              Recently Processed
+            </Text>
+            <View className="gap-3">
+              {processedRequests.slice(0, 10).map((request) => (
+                <View
+                  key={request.id}
+                  className="bg-white rounded-xl p-4 border border-gray-200"
+                >
+                  <View className="flex-row items-start justify-between mb-2">
+                    <View className="flex-1">
+                      <Text className="text-base font-bold text-gray-900">
+                        {request.eventName}
+                      </Text>
+                      <Text className="text-xs text-gray-500">
+                        {request.userName}
+                      </Text>
+                    </View>
+                    <View
+                      className={`px-2 py-1 rounded-lg ${
+                        request.status === "approved"
+                          ? "bg-green-100"
+                          : "bg-red-100"
+                      }`}
+                    >
+                      <Text
+                        className={`text-xs font-bold ${
+                          request.status === "approved"
+                            ? "text-green-800"
+                            : "text-red-800"
+                        }`}
+                      >
+                        {request.status.toUpperCase()}
+                      </Text>
+                    </View>
+                  </View>
+                  {request.adminResponse && (
+                    <Text className="text-xs text-gray-600 mb-2">
+                      Response: {request.adminResponse}
+                    </Text>
+                  )}
+                  <Text className="text-xs text-gray-400">
+                    Processed {request.processedAt && formatDate(request.processedAt)}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+      </ScrollView>
+
+      {/* Action Modal */}
+      <Modal
+        visible={showModal}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowModal(false)}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <View className="flex-1 bg-black/50 justify-end">
+            <TouchableWithoutFeedback>
+              <View
+                className="bg-white rounded-t-3xl p-6"
+                style={{ paddingBottom: insets.bottom + 24 }}
+              >
+                <Text className="text-xl font-bold text-gray-900 mb-2">
+                  {modalType === "approve" ? "Approve Refund" : "Deny Refund"}
+                </Text>
+                <Text className="text-sm text-gray-600 mb-4">
+                  {selectedRequest?.eventName} - {selectedRequest?.userName}
+                </Text>
+
+                <View className="mb-4">
+                  <Text className="text-sm font-medium text-gray-700 mb-2">
+                    Message to User <Text className="text-red-500">*</Text>
+                  </Text>
+                  <TextInput
+                    value={adminResponse}
+                    onChangeText={setAdminResponse}
+                    placeholder=""
+                    placeholderTextColor="#9CA3AF"
+                    multiline
+                    numberOfLines={3}
+                    className="border border-gray-300 rounded-xl p-4 text-base text-gray-900 min-h-[80px]"
+                    style={{ textAlignVertical: "top" }}
+                    returnKeyType="done"
+                    blurOnSubmit={true}
+                  />
+                  <Text className="text-xs text-gray-500 mt-1">
+                    * Required: {modalType === "approve" 
+                      ? "Provide a confirmation message for the user" 
+                      : "Explain why the refund is being denied"}
+                  </Text>
+                </View>
+
+                <View className="flex-row gap-3">
+                  <Pressable
+                    onPress={() => {
+                      Keyboard.dismiss();
+                      setShowModal(false);
+                      setAdminResponse("");
+                    }}
+                    disabled={processing}
+                    className="flex-1 bg-gray-200 active:bg-gray-300 rounded-xl p-4 items-center"
+                  >
+                    <Text className="text-base font-bold text-gray-700">Cancel</Text>
+                  </Pressable>
+
+                  <Pressable
+                    onPress={handleAction}
+                    disabled={processing}
+                    className={`flex-1 rounded-xl p-4 items-center disabled:opacity-50 ${
+                      modalType === "approve"
+                        ? "bg-green-500 active:bg-green-600"
+                        : "bg-red-500 active:bg-red-600"
+                    }`}
+                  >
+                    {processing ? (
+                      <ActivityIndicator color="white" />
+                    ) : (
+                      <Text className="text-base font-bold text-white">
+                        {modalType === "approve" ? "Approve" : "Deny"}
+                      </Text>
+                    )}
+                  </Pressable>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </View>
+  );
+}

--- a/src/frontend/mobile/app/ticket-detail.tsx
+++ b/src/frontend/mobile/app/ticket-detail.tsx
@@ -6,11 +6,16 @@ import {
   Pressable,
   Image,
   ActivityIndicator,
+  Modal,
+  TextInput,
+  Alert,
+  Keyboard,
+  TouchableWithoutFeedback,
 } from "react-native";
 import { useLocalSearchParams, router } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import QRCode from "react-native-qrcode-svg";
-import { getUserTickets, type Ticket } from "./_lib/api";
+import { getUserTickets, createRefundRequest, cancelSignup, type Ticket } from "./_lib/api";
 import { useAuth } from "./_context/AuthContext";
 
 export default function TicketDetailScreen() {
@@ -19,6 +24,11 @@ export default function TicketDetailScreen() {
   const insets = useSafeAreaInsets();
   const [ticket, setTicket] = useState<Ticket | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showRefundModal, setShowRefundModal] = useState(false);
+  const [showCancelModal, setShowCancelModal] = useState(false);
+  const [refundReason, setRefundReason] = useState("");
+  const [submittingRefund, setSubmittingRefund] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
 
   useEffect(() => {
     loadTicket();
@@ -58,6 +68,63 @@ export default function TicketDetailScreen() {
   const formatPrice = (price: number) => {
     if (price === 0) return "Free Event";
     return `$${(price / 100).toFixed(2)}`;
+  };
+
+  const handleRequestRefund = async () => {
+    if (!ticket) return;
+    
+    const trimmedReason = refundReason.trim();
+    if (!trimmedReason) {
+      Alert.alert("Required", "Please provide a reason for your refund request.");
+      return;
+    }
+    
+    setSubmittingRefund(true);
+    try {
+      const result = await createRefundRequest(ticket.ticketId, trimmedReason);
+      
+      if (result.error) {
+        Alert.alert("Error", result.error);
+      } else {
+        Alert.alert(
+          "Refund Requested",
+          "Your refund request has been submitted. An admin will review it shortly.",
+          [{ text: "OK", onPress: () => {
+            setShowRefundModal(false);
+            setRefundReason("");
+            loadTicket(); // Reload to show updated status
+          }}]
+        );
+      }
+    } catch (err: any) {
+      Alert.alert("Error", err?.message || "Failed to submit refund request");
+    } finally {
+      setSubmittingRefund(false);
+    }
+  };
+
+  const handleCancelSignup = async () => {
+    if (!ticket) return;
+    
+    setShowCancelModal(false);
+    setCancelling(true);
+    try {
+      const result = await cancelSignup(ticket.eventId);
+      
+      if (result.error) {
+        Alert.alert("Error", result.error);
+      } else {
+        Alert.alert(
+          "Ticket Cancelled",
+          "Your ticket has been cancelled successfully.",
+          [{ text: "OK", onPress: () => router.back() }]
+        );
+      }
+    } catch (err: any) {
+      Alert.alert("Error", err?.message || "Failed to cancel ticket");
+    } finally {
+      setCancelling(false);
+    }
   };
 
   if (loading) {
@@ -192,6 +259,67 @@ export default function TicketDetailScreen() {
           </View>
         </View>
 
+        {/* Refund Status Banner */}
+        {ticket.refundRequest && ticket.refundRequest.status === 'pending' && (
+          <View className="bg-yellow-50 border border-yellow-300 rounded-2xl p-4 mb-6">
+            <View className="flex-row items-center gap-2 mb-2">
+              <Text className="text-xl">⏳</Text>
+              <Text className="text-base font-bold text-yellow-900">
+                Refund Requested
+              </Text>
+            </View>
+            <Text className="text-sm text-yellow-800">
+              Your refund request is pending admin review. We'll notify you once it's processed.
+            </Text>
+          </View>
+        )}
+
+        {ticket.refundRequest && ticket.refundRequest.status === 'denied' && ticket.refundRequest.adminResponse && (
+          <View className="bg-red-50 border border-red-300 rounded-2xl p-4 mb-6">
+            <View className="flex-row items-center gap-2 mb-2">
+              <Text className="text-xl">❌</Text>
+              <Text className="text-base font-bold text-red-900">
+                Refund Denied
+              </Text>
+            </View>
+            <Text className="text-sm text-red-800 mb-2">
+              {ticket.refundRequest.adminResponse}
+            </Text>
+            <Text className="text-xs text-red-600">
+              If you have questions, please contact support.
+            </Text>
+          </View>
+        )}
+
+        {/* Request Refund Button (only for paid events without pending request) */}
+        {ticket.eventPrice > 0 && !ticket.refundRequest && (
+          <Pressable
+            onPress={() => setShowRefundModal(true)}
+            className="bg-red-500 active:bg-red-600 rounded-2xl p-4 mb-6 items-center"
+          >
+            <Text className="text-base font-bold text-white">
+              Request Refund
+            </Text>
+          </Pressable>
+        )}
+
+        {/* Cancel Signup Button (only for free events) */}
+        {ticket.eventPrice === 0 && (
+          <Pressable
+            onPress={() => setShowCancelModal(true)}
+            disabled={cancelling}
+            className="bg-gray-500 active:bg-gray-600 rounded-2xl p-4 mb-6 items-center disabled:opacity-50"
+          >
+            {cancelling ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <Text className="text-base font-bold text-white">
+                Cancel Sign-Up
+              </Text>
+            )}
+          </Pressable>
+        )}
+
         {/* QR Code Card */}
         <View className="bg-white rounded-2xl p-6 items-center border border-gray-100 shadow-sm">
           <Text className="text-lg font-bold text-gray-900 mb-2">
@@ -228,6 +356,104 @@ export default function TicketDetailScreen() {
           </Text>
         </View>
       </ScrollView>
+
+      {/* Refund Request Modal */}
+      <Modal
+        visible={showRefundModal}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowRefundModal(false)}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <View className="flex-1 bg-black/50 justify-end">
+            <TouchableWithoutFeedback>
+              <View className="bg-white rounded-t-3xl p-6" style={{ paddingBottom: insets.bottom + 24 }}>
+                <Text className="text-xl font-bold text-gray-900 mb-2">
+                  Request Refund
+                </Text>
+                <Text className="text-sm text-gray-600 mb-4">
+                  Please let us know why you're requesting a refund. This information is required.
+                </Text>
+
+                <TextInput
+                  value={refundReason}
+                  onChangeText={setRefundReason}
+                  placeholder="Reason for refund (required)"
+                  multiline
+                  numberOfLines={4}
+                  className="border border-gray-300 rounded-xl p-4 text-base mb-4 min-h-[100px]"
+                  style={{ textAlignVertical: "top" }}
+                  returnKeyType="done"
+                  blurOnSubmit={true}
+                />
+
+                <View className="flex-row gap-3">
+                  <Pressable
+                    onPress={() => {
+                      Keyboard.dismiss();
+                      setShowRefundModal(false);
+                      setRefundReason("");
+                    }}
+                    disabled={submittingRefund}
+                    className="flex-1 bg-gray-200 active:bg-gray-300 rounded-xl p-4 items-center"
+                  >
+                    <Text className="text-base font-bold text-gray-700">Cancel</Text>
+                  </Pressable>
+
+                  <Pressable
+                    onPress={handleRequestRefund}
+                    disabled={submittingRefund}
+                    className="flex-1 bg-red-500 active:bg-red-600 rounded-xl p-4 items-center disabled:opacity-50"
+                  >
+                    {submittingRefund ? (
+                      <ActivityIndicator color="white" />
+                    ) : (
+                      <Text className="text-base font-bold text-white">Submit Request</Text>
+                    )}
+                  </Pressable>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+
+      {/* Cancel Confirmation Modal */}
+      <Modal
+        visible={showCancelModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowCancelModal(false)}
+      >
+        <View className="flex-1 justify-center items-center bg-black/50 px-6">
+          <View className="bg-white rounded-2xl p-6 w-full max-w-sm">
+            <Text className="text-xl font-bold text-gray-900 mb-2">
+              Cancel Sign-Up
+            </Text>
+            <Text className="text-sm text-gray-600 mb-6">
+              Are you sure you want to cancel your registration for this event? This action cannot be undone.
+            </Text>
+            <View className="flex-row gap-3">
+              <Pressable
+                onPress={() => setShowCancelModal(false)}
+                className="flex-1 py-3 border border-gray-300 rounded-xl active:bg-gray-50"
+              >
+                <Text className="text-center text-sm font-medium text-gray-700">
+                  No, Keep It
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={handleCancelSignup}
+                className="flex-1 py-3 bg-red-500 rounded-xl active:bg-red-600"
+              >
+                <Text className="text-center text-sm font-semibold text-white">
+                  Yes, Cancel
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }

--- a/test/backend/__mocks__/drizzle-orm.js
+++ b/test/backend/__mocks__/drizzle-orm.js
@@ -3,4 +3,5 @@ module.exports = {
   sql: jest.fn((...args) => ({ type: 'sql', args })),
   and: jest.fn((...args) => ({ type: 'and', args })),
   asc: jest.fn((...args) => ({ type: 'asc', args })),
+  desc: jest.fn((...args) => ({ type: 'desc', args })),
 };

--- a/test/backend/events.service.spec.ts
+++ b/test/backend/events.service.spec.ts
@@ -7,11 +7,13 @@ jest.mock('../../src/backend/src/payments/payments.service', () => ({
   PaymentsService: jest.fn(),
 }));
 jest.mock('../../src/backend/src/db/schema', () => ({
-  events: { id: 'events.id', name: 'events.name', date: 'events.date' },
-  tickets: { id: 'tickets.id', eventId: 'tickets.eventId', userId: 'tickets.userId' },
+  events: { id: 'events.id', name: 'events.name', date: 'events.date', price: 'events.price', imageUrl: 'events.imageUrl' },
+  tickets: { id: 'tickets.id', eventId: 'tickets.eventId', userId: 'tickets.userId', checkedIn: 'tickets.checkedIn', busSeat: 'tickets.busSeat', tableSeat: 'tickets.tableSeat', qrCodeData: 'tickets.qrCodeData', createdAt: 'tickets.createdAt' },
   tableSeats: { id: 'tableSeats.id', eventId: 'tableSeats.eventId' },
   busSeats: { id: 'busSeats.id', eventId: 'busSeats.eventId' },
   seatReservations: { id: 'seatReservations.id' },
+  refundRequests: { id: 'refundRequests.id', ticketId: 'refundRequests.ticketId', userId: 'refundRequests.userId', status: 'refundRequests.status', adminResponse: 'refundRequests.adminResponse', createdAt: 'refundRequests.createdAt' },
+  payments: { id: 'payments.id', ticketId: 'payments.ticketId' },
 }));
 
 const mockCreateTableSeats = jest.fn();
@@ -30,7 +32,7 @@ function createDbChain(result: any = []) {
   chain.catch = (fn: any) => Promise.resolve(result).catch(fn);
 
   [
-    'select', 'from', 'where', 'orderBy', 'limit', 'innerJoin',
+    'select', 'from', 'where', 'orderBy', 'limit', 'innerJoin', 'leftJoin',
     'insert', 'values', 'returning', 'update', 'set', 'delete',
   ].forEach((method) => {
     chain[method] = jest.fn().mockReturnValue(chain);
@@ -130,7 +132,11 @@ describe('EventsService', () => {
   it('getTicketsForUser returns tickets from database', async () => {
     const tickets = [{ ticketId: 1, eventName: 'Gala' }];
     mockDb.select.mockReturnValue(createDbChain(tickets));
-    expect(await service.getTicketsForUser(5)).toEqual(tickets);
+    const result = await service.getTicketsForUser(5);
+    // Service maps rows and adds refundRequest field; check the stable fields
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ ticketId: 1, eventName: 'Gala' });
+    expect(result[0]).toHaveProperty('refundRequest');
   });
 
   it('releaseReservation deletes by session id', async () => {

--- a/test/backend/refund-requests.controller.spec.ts
+++ b/test/backend/refund-requests.controller.spec.ts
@@ -1,0 +1,184 @@
+import 'reflect-metadata';
+
+jest.mock('../../src/backend/src/refund-requests/refund-requests.service', () => ({
+  RefundRequestsService: jest.fn(),
+}));
+jest.mock('../../src/backend/src/auth/jwt-auth.guard', () => ({
+  JwtAuthGuard: class {
+    canActivate() {
+      return true;
+    }
+  },
+}));
+jest.mock('../../src/backend/src/db/schema', () => ({}));
+
+import { RefundRequestsController } from '../../src/backend/src/refund-requests/refund-requests.controller';
+
+describe('RefundRequestsController', () => {
+  let controller: RefundRequestsController;
+  let mockService: any;
+
+  beforeEach(() => {
+    mockService = {
+      createRefundRequest: jest.fn(),
+      getAllRefundRequests: jest.fn(),
+      getUserRefundRequests: jest.fn(),
+      approveRefundRequest: jest.fn(),
+      denyRefundRequest: jest.fn(),
+    };
+    controller = new RefundRequestsController(mockService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('createRefundRequest', () => {
+    it('creates refund request with user from JWT', async () => {
+      const req = { user: { sub: 5 } } as any;
+      const body = { ticketId: 10, reason: 'Event cancelled' };
+
+      mockService.createRefundRequest.mockResolvedValue({
+        success: true,
+        requestId: 1,
+      });
+
+      const result = await controller.createRefundRequest(req, body);
+
+      expect(result).toEqual({ success: true, requestId: 1 });
+      expect(mockService.createRefundRequest).toHaveBeenCalledWith(
+        5,
+        10,
+        'Event cancelled',
+      );
+    });
+
+    it('handles optional reason', async () => {
+      const req = { user: { sub: 5 } } as any;
+      const body = { ticketId: 10 };
+
+      mockService.createRefundRequest.mockResolvedValue({
+        success: true,
+        requestId: 2,
+      });
+
+      await controller.createRefundRequest(req, body);
+
+      expect(mockService.createRefundRequest).toHaveBeenCalledWith(
+        5,
+        10,
+        undefined,
+      );
+    });
+  });
+
+  describe('getAllRefundRequests', () => {
+    it('returns all refund requests for admin', async () => {
+      const req = { user: { sub: 1 } } as any;
+      const requests = [
+        { id: 1, status: 'pending' },
+        { id: 2, status: 'approved' },
+      ];
+
+      mockService.getAllRefundRequests.mockResolvedValue(requests);
+
+      const result = await controller.getAllRefundRequests(req);
+
+      expect(result).toEqual(requests);
+      expect(mockService.getAllRefundRequests).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('getUserRefundRequests', () => {
+    it('returns user-specific refund requests', async () => {
+      const req = { user: { sub: 5 } } as any;
+      const requests = [{ id: 1, userId: 5, status: 'pending' }];
+
+      mockService.getUserRefundRequests.mockResolvedValue(requests);
+
+      const result = await controller.getUserRefundRequests(req);
+
+      expect(result).toEqual(requests);
+      expect(mockService.getUserRefundRequests).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe('approveRefundRequest', () => {
+    it('approves refund with admin user and response', async () => {
+      const req = { user: { sub: 1 } } as any;
+      const body = { adminResponse: 'Approved - event cancelled by organizer' };
+
+      mockService.approveRefundRequest.mockResolvedValue({ success: true });
+
+      const result = await controller.approveRefundRequest('10', req, body);
+
+      expect(result).toEqual({ success: true });
+      expect(mockService.approveRefundRequest).toHaveBeenCalledWith(
+        10,
+        1,
+        'Approved - event cancelled by organizer',
+      );
+    });
+
+    it('handles optional admin response', async () => {
+      const req = { user: { sub: 1 } } as any;
+      const body = {};
+
+      mockService.approveRefundRequest.mockResolvedValue({ success: true });
+
+      await controller.approveRefundRequest('10', req, body);
+
+      expect(mockService.approveRefundRequest).toHaveBeenCalledWith(
+        10,
+        1,
+        undefined,
+      );
+    });
+
+    it('converts string id to number', async () => {
+      const req = { user: { sub: 1 } } as any;
+      const body = { adminResponse: 'OK' };
+
+      mockService.approveRefundRequest.mockResolvedValue({ success: true });
+
+      await controller.approveRefundRequest('123', req, body);
+
+      expect(mockService.approveRefundRequest).toHaveBeenCalledWith(
+        123,
+        1,
+        'OK',
+      );
+    });
+  });
+
+  describe('denyRefundRequest', () => {
+    it('denies refund with admin reason', async () => {
+      const req = { user: { sub: 1 } } as any;
+      const body = { adminResponse: 'Event already occurred' };
+
+      mockService.denyRefundRequest.mockResolvedValue({ success: true });
+
+      const result = await controller.denyRefundRequest('10', req, body);
+
+      expect(result).toEqual({ success: true });
+      expect(mockService.denyRefundRequest).toHaveBeenCalledWith(
+        10,
+        1,
+        'Event already occurred',
+      );
+    });
+
+    it('handles optional admin response', async () => {
+      const req = { user: { sub: 1 } } as any;
+      const body = {};
+
+      mockService.denyRefundRequest.mockResolvedValue({ success: true });
+
+      await controller.denyRefundRequest('10', req, body);
+
+      expect(mockService.denyRefundRequest).toHaveBeenCalledWith(
+        10,
+        1,
+        undefined,
+      );
+    });
+  });
+});

--- a/test/backend/refund-requests.service.spec.ts
+++ b/test/backend/refund-requests.service.spec.ts
@@ -1,0 +1,308 @@
+import 'reflect-metadata';
+
+jest.mock('../../src/backend/src/database/database.service', () => ({
+  DatabaseService: jest.fn(),
+}));
+jest.mock('../../src/backend/src/payments/payments.service', () => ({
+  PaymentsService: jest.fn(),
+}));
+jest.mock('../../src/backend/src/db/schema', () => ({
+  refundRequests: {
+    id: 'refundRequests.id',
+    ticketId: 'refundRequests.ticketId',
+    userId: 'refundRequests.userId',
+    status: 'refundRequests.status',
+    createdAt: 'refundRequests.createdAt',
+  },
+  users: { id: 'users.id', isSystemAdmin: 'users.isSystemAdmin' },
+  tickets: { id: 'tickets.id' },
+  events: { id: 'events.id', name: 'events.name' },
+  payments: { id: 'payments.id', ticketId: 'payments.ticketId' },
+}));
+
+import { RefundRequestsService } from '../../src/backend/src/refund-requests/refund-requests.service';
+
+function createDbChain(result: any = []) {
+  const chain: any = {};
+  chain.then = (resolve: any, reject: any) =>
+    Promise.resolve(result).then(resolve, reject);
+  chain.catch = (fn: any) => Promise.resolve(result).catch(fn);
+
+  [
+    'select',
+    'from',
+    'where',
+    'orderBy',
+    'limit',
+    'innerJoin',
+    'leftJoin',
+    'insert',
+    'values',
+    'returning',
+    'update',
+    'set',
+    'delete',
+  ].forEach((method) => {
+    chain[method] = jest.fn().mockReturnValue(chain);
+  });
+
+  return chain;
+}
+
+describe('RefundRequestsService', () => {
+  let service: RefundRequestsService;
+  let mockDb: any;
+  let mockPaymentsService: any;
+
+  beforeEach(() => {
+    mockDb = {
+      select: jest.fn(),
+      insert: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+    mockPaymentsService = {
+      refundPayment: jest.fn(),
+    };
+    service = new RefundRequestsService(
+      { db: mockDb } as any,
+      mockPaymentsService,
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('createRefundRequest', () => {
+    it('creates refund request for valid ticket owned by user', async () => {
+      const ticket = { id: 1, userId: 5, eventId: 10, price: 5000 };
+      const payment = { id: 100 };
+
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([ticket])) // ticket check
+        .mockReturnValueOnce(createDbChain([])) // no pending request
+        .mockReturnValueOnce(createDbChain([payment])); // payment exists
+
+      mockDb.insert.mockReturnValue(
+        createDbChain([{ id: 1, status: 'pending' }]),
+      );
+
+      const result = await service.createRefundRequest(5, 1, 'Event cancelled');
+      expect(result).toEqual({ success: true, requestId: 1 });
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('returns error if ticket not found', async () => {
+      mockDb.select.mockReturnValue(createDbChain([]));
+      const result = await service.createRefundRequest(5, 999, 'No ticket');
+      expect(result).toEqual({ error: 'Ticket not found or does not belong to you' });
+    });
+
+    it('returns error if ticket not owned by user', async () => {
+      // First query checks tickets.id AND tickets.userId - should return empty if userId doesn't match
+      mockDb.select.mockReturnValueOnce(createDbChain([]));
+      
+      const result = await service.createRefundRequest(5, 1, 'Wrong user');
+      expect(result).toEqual({ error: 'Ticket not found or does not belong to you' });
+    });
+
+    it('returns error if pending refund request already exists', async () => {
+      mockDb.select
+        .mockReturnValueOnce(
+          createDbChain([{ id: 1, userId: 5, eventId: 10 }]),
+        )
+        .mockReturnValueOnce(createDbChain([{ id: 1, status: 'pending' }]));
+
+      const result = await service.createRefundRequest(5, 1, 'Duplicate');
+      expect(result).toEqual({
+        error: 'A refund request is already pending for this ticket',
+      });
+    });
+
+    it('handles free events (no payment)', async () => {
+      const freeTicket = { id: 1, userId: 5, eventId: 10, price: 0 };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([freeTicket]))
+        .mockReturnValueOnce(createDbChain([]))
+        .mockReturnValueOnce(createDbChain([])); // no payment
+
+      mockDb.insert.mockReturnValue(
+        createDbChain([{ id: 2, status: 'pending' }]),
+      );
+
+      const result = await service.createRefundRequest(5, 1, 'Free event');
+      expect(result).toEqual({ success: true, requestId: 2 });
+    });
+  });
+
+  describe('getAllRefundRequests', () => {
+    it('returns all refund requests for admin user', async () => {
+      const adminUser = { id: 1, isSystemAdmin: true };
+      const requests = [
+        { id: 1, status: 'pending' },
+        { id: 2, status: 'approved' },
+      ];
+
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([adminUser]))
+        .mockReturnValueOnce(createDbChain(requests));
+
+      const result = await service.getAllRefundRequests(1);
+      expect(result).toEqual(requests);
+    });
+
+    it('throws error for non-admin user', async () => {
+      mockDb.select.mockReturnValue(
+        createDbChain([{ id: 2, isSystemAdmin: false }]),
+      );
+
+      await expect(service.getAllRefundRequests(2)).rejects.toThrow(
+        'Admin access required',
+      );
+    });
+  });
+
+  describe('approveRefundRequest', () => {
+    it('approves refund, processes payment, and deletes ticket', async () => {
+      const admin = { id: 1, isSystemAdmin: true };
+      const request = {
+        id: 10,
+        ticketId: 5,
+        paymentId: 100,
+        status: 'pending',
+      };
+
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([admin]))
+        .mockReturnValueOnce(createDbChain([request]));
+
+      mockPaymentsService.refundPayment.mockResolvedValue({ success: true });
+      mockDb.update.mockReturnValue(createDbChain());
+      mockDb.delete.mockReturnValue(createDbChain());
+
+      const result = await service.approveRefundRequest(
+        10,
+        1,
+        'Approved by admin',
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(mockPaymentsService.refundPayment).toHaveBeenCalledWith(100, 1);
+      expect(mockDb.update).toHaveBeenCalled();
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it('returns error if request already processed', async () => {
+      mockDb.select
+        .mockReturnValueOnce(
+          createDbChain([{ id: 1, isSystemAdmin: true }]),
+        )
+        .mockReturnValueOnce(
+          createDbChain([{ id: 10, status: 'approved' }]),
+        );
+
+      const result = await service.approveRefundRequest(10, 1);
+      expect(result).toEqual({
+        error: 'Refund request has already been processed',
+      });
+    });
+
+    it('returns error if Stripe refund fails', async () => {
+      mockDb.select
+        .mockReturnValueOnce(
+          createDbChain([{ id: 1, isSystemAdmin: true }]),
+        )
+        .mockReturnValueOnce(
+          createDbChain([
+            { id: 10, ticketId: 5, paymentId: 100, status: 'pending' },
+          ]),
+        );
+
+      mockPaymentsService.refundPayment.mockResolvedValue({
+        error: 'Refund failed',
+      });
+
+      const result = await service.approveRefundRequest(10, 1);
+      expect(result).toEqual({ error: 'Refund failed: Refund failed' });
+    });
+
+    it('handles free event refund (no payment)', async () => {
+      mockDb.select
+        .mockReturnValueOnce(
+          createDbChain([{ id: 1, isSystemAdmin: true }]),
+        )
+        .mockReturnValueOnce(
+          createDbChain([
+            { id: 10, ticketId: 5, paymentId: null, status: 'pending' },
+          ]),
+        );
+
+      mockDb.update.mockReturnValue(createDbChain());
+      mockDb.delete.mockReturnValue(createDbChain());
+
+      const result = await service.approveRefundRequest(10, 1);
+      expect(result).toEqual({ success: true });
+      expect(mockPaymentsService.refundPayment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('denyRefundRequest', () => {
+    it('denies refund request with admin response', async () => {
+      mockDb.select
+        .mockReturnValueOnce(
+          createDbChain([{ id: 1, isSystemAdmin: true }]),
+        )
+        .mockReturnValueOnce(
+          createDbChain([{ id: 10, status: 'pending' }]),
+        );
+
+      mockDb.update.mockReturnValue(createDbChain());
+
+      const result = await service.denyRefundRequest(
+        10,
+        1,
+        'Cannot refund after event date',
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it('returns error if not admin', async () => {
+      mockDb.select.mockReturnValue(
+        createDbChain([{ id: 2, isSystemAdmin: false }]),
+      );
+
+      const result = await service.denyRefundRequest(10, 2, 'Denied');
+      expect(result).toEqual({ error: 'Admin access required' });
+    });
+
+    it('returns error if request already processed', async () => {
+      mockDb.select
+        .mockReturnValueOnce(
+          createDbChain([{ id: 1, isSystemAdmin: true }]),
+        )
+        .mockReturnValueOnce(
+          createDbChain([{ id: 10, status: 'denied' }]),
+        );
+
+      const result = await service.denyRefundRequest(10, 1, 'Already done');
+      expect(result).toEqual({
+        error: 'Refund request has already been processed',
+      });
+    });
+  });
+
+  describe('getUserRefundRequests', () => {
+    it('returns refund requests for specific user', async () => {
+      const userRequests = [
+        { id: 1, userId: 5, status: 'pending' },
+        { id: 2, userId: 5, status: 'approved' },
+      ];
+
+      mockDb.select.mockReturnValue(createDbChain(userRequests));
+
+      const result = await service.getUserRefundRequests(5);
+      expect(result).toEqual(userRequests);
+    });
+  });
+});

--- a/test/frontend/__mocks__/expo-router.js
+++ b/test/frontend/__mocks__/expo-router.js
@@ -1,5 +1,7 @@
 const React = require('react');
 
+let mockParams = {};
+
 const mockRouter = {
   back: jest.fn(),
   push: jest.fn(),
@@ -10,7 +12,7 @@ const mockRouter = {
 
 const useRouter = () => mockRouter;
 
-const useLocalSearchParams = jest.fn(() => ({}));
+const useLocalSearchParams = jest.fn(() => mockParams);
 
 function Stack({ children }) {
   return React.createElement('div', null, children);
@@ -30,8 +32,12 @@ function Link({ children }) {
 module.exports = {
   useRouter,
   useLocalSearchParams,
+  router: mockRouter,
   Stack,
   Redirect,
   Link,
   __mockRouter: mockRouter,
+  __setParams: (params) => {
+    mockParams = params;
+  },
 };

--- a/test/frontend/__mocks__/react-native-qrcode-svg.js
+++ b/test/frontend/__mocks__/react-native-qrcode-svg.js
@@ -1,0 +1,13 @@
+const React = require('react');
+
+const QRCode = React.forwardRef(function QRCode({ value, size, testID }, ref) {
+  return React.createElement('div', {
+    ref,
+    'data-testid': testID || 'qr-code',
+    'data-value': value,
+    style: { width: size, height: size },
+  });
+});
+
+module.exports = QRCode;
+module.exports.default = QRCode;

--- a/test/frontend/__mocks__/react-native.js
+++ b/test/frontend/__mocks__/react-native.js
@@ -114,6 +114,20 @@ const Alert = {
   alert: jest.fn(),
 };
 
+const Keyboard = {
+  dismiss: jest.fn(),
+};
+
+const TouchableWithoutFeedback = React.forwardRef(
+  function TouchableWithoutFeedback({ onPress, children }, ref) {
+    return React.createElement(
+      'div',
+      { ref, onClick: onPress },
+      children,
+    );
+  },
+);
+
 const Platform = {
   OS: 'ios',
   select: (obj) => obj.ios ?? obj.default,
@@ -137,6 +151,8 @@ module.exports = {
   Modal,
   RefreshControl,
   Alert,
+  Keyboard,
+  TouchableWithoutFeedback,
   Platform,
   useWindowDimensions,
   StyleSheet,

--- a/test/frontend/events-screen.test.tsx
+++ b/test/frontend/events-screen.test.tsx
@@ -171,7 +171,7 @@ describe('EventsScreen', () => {
     expect(mockRouter.push).toHaveBeenCalledWith('/event-signup?eventId=1');
   });
 
-  it('shows cancel flow for signed-up free events and refund for paid events', async () => {
+  it('shows signed-up badge for events the user is registered for (no cancel/refund buttons)', async () => {
     mockGetEvents.mockResolvedValue([
       mockEvent({ id: 5, price: 0 }),
       mockEvent({ id: 3, price: 2500 }),
@@ -180,14 +180,12 @@ describe('EventsScreen', () => {
     render(<EventsScreen />);
 
     await waitFor(() => {
-      expect(screen.getByText('Cancel Sign-Up')).toBeTruthy();
-      expect(screen.getByText('Request Refund')).toBeTruthy();
+      const signedUpBadges = screen.getAllByText('✓ Signed Up');
+      expect(signedUpBadges.length).toBe(2);
     });
 
-    fireEvent.click(screen.getByText('Cancel Sign-Up'));
-    await waitFor(() => {
-      expect(screen.getByText('Cancel Ticket')).toBeTruthy();
-      expect(screen.getByText('Are you sure you want to cancel this ticket?')).toBeTruthy();
-    });
+    // Main events list should not show cancel/refund buttons anymore
+    expect(screen.queryByText('Cancel Sign-Up')).toBeNull();
+    expect(screen.queryByText('Request Refund')).toBeNull();
   });
 });

--- a/test/frontend/jest.config.js
+++ b/test/frontend/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
     '^react-dom/(.*)$': '<rootDir>/test/node_modules/react-dom/$1',
     '^react-native$': '<rootDir>/test/frontend/__mocks__/react-native.js',
     '^react-native/(.*)$': '<rootDir>/test/frontend/__mocks__/react-native.js',
+    '^react-native-qrcode-svg$': '<rootDir>/test/frontend/__mocks__/react-native-qrcode-svg.js',
     '^expo-router$': '<rootDir>/test/frontend/__mocks__/expo-router.js',
     '^react-native-safe-area-context$':
       '<rootDir>/test/frontend/__mocks__/react-native-safe-area-context.js',

--- a/test/frontend/refund-requests.test.tsx
+++ b/test/frontend/refund-requests.test.tsx
@@ -1,0 +1,328 @@
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+
+// Mocks already handled by jest.config moduleNameMapper
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+
+const mockGetAllRefundRequests = jest.fn();
+const mockApproveRefundRequest = jest.fn();
+const mockDenyRefundRequest = jest.fn();
+
+jest.mock('../../src/frontend/mobile/app/_lib/api', () => ({
+  getAllRefundRequests: mockGetAllRefundRequests,
+  approveRefundRequest: mockApproveRefundRequest,
+  denyRefundRequest: mockDenyRefundRequest,
+}));
+
+jest.mock('../../src/frontend/mobile/app/_context/AuthContext', () => ({
+  useAuth: jest.fn(() => ({ isAdmin: true })),
+}));
+
+import RefundRequestsScreen from '../../src/frontend/mobile/app/refund-requests';
+import { Alert } from 'react-native';
+
+describe('RefundRequestsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReplace.mockClear();
+  });
+
+  it('renders loading state initially', () => {
+    mockGetAllRefundRequests.mockReturnValue(new Promise(() => {})); // Never resolves
+    render(<RefundRequestsScreen />);
+    expect(screen.getByRole('progressbar')).toBeTruthy();
+  });
+
+  it('displays pending refund requests', async () => {
+    const requests = [
+      {
+        id: 1,
+        eventName: 'Annual Gala 2026',
+        userName: 'John Doe',
+        userEmail: 'john@example.com',
+        reason: 'Cannot attend',
+        status: 'pending',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ];
+
+    mockGetAllRefundRequests.mockResolvedValue(requests);
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Annual Gala 2026')).toBeTruthy();
+      expect(screen.getByText('John Doe • john@example.com')).toBeTruthy();
+      expect(screen.getByText('Cannot attend')).toBeTruthy();
+      expect(screen.getByText('PENDING')).toBeTruthy();
+    });
+  });
+
+  it('displays "All caught up" when no pending requests', async () => {
+    mockGetAllRefundRequests.mockResolvedValue([]);
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('All caught up!')).toBeTruthy();
+      expect(
+        screen.getByText('No pending refund requests at the moment'),
+      ).toBeTruthy();
+    });
+  });
+
+  it('opens approve modal when approve button clicked', async () => {
+    const requests = [
+      {
+        id: 1,
+        eventName: 'Test Event',
+        userName: 'Test User',
+        status: 'pending',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ];
+
+    mockGetAllRefundRequests.mockResolvedValue(requests);
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('✓ Approve')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('✓ Approve'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Approve Refund')).toBeTruthy();
+      expect(screen.getByText('Message to User')).toBeTruthy();
+    });
+  });
+
+  it('validates required message for approve', async () => {
+    const requests = [
+      {
+        id: 1,
+        eventName: 'Test Event',
+        userName: 'Test User',
+        status: 'pending',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ];
+
+    mockGetAllRefundRequests.mockResolvedValue(requests);
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('✓ Approve'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Approve Refund')).toBeTruthy(); // Modal header
+    });
+
+    const approveButtons = screen.getAllByRole('button');
+    const submitButton = approveButtons.find(btn => 
+      btn.textContent === 'Approve' // Exact match, not "✓ Approve"
+    );
+    fireEvent.click(submitButton!);
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Required',
+        expect.stringContaining('confirmation message'),
+      );
+    });
+
+    expect(mockApproveRefundRequest).not.toHaveBeenCalled();
+  });
+
+  it('validates required message for deny', async () => {
+    const requests = [
+      {
+        id: 1,
+        eventName: 'Test Event',
+        userName: 'Test User',
+        status: 'pending',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ];
+
+    mockGetAllRefundRequests.mockResolvedValue(requests);
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('✗ Deny'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Deny Refund')).toBeTruthy(); // Modal header
+    });
+
+    const denyButtons = screen.getAllByRole('button');
+    const submitButton = denyButtons.find(btn => 
+      btn.textContent === 'Deny' // Exact match, not "✗ Deny"
+    );
+    fireEvent.click(submitButton!);
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Required',
+        expect.stringContaining('reason'),
+      );
+    });
+
+    expect(mockDenyRefundRequest).not.toHaveBeenCalled();
+  });
+
+  it('approves refund with message and reloads data', async () => {
+    const requests = [
+      {
+        id: 1,
+        eventName: 'Test Event',
+        userName: 'Test User',
+        status: 'pending',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ];
+
+    mockGetAllRefundRequests.mockResolvedValue(requests); // Will return requests for all calls
+    mockApproveRefundRequest.mockResolvedValue({ success: true });
+    
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('✓ Approve'));
+    });
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'Refund approved' } });
+    });
+
+    const approveButtons = screen.getAllByRole('button');
+    const submitApproveButton = approveButtons.find(btn => btn.textContent?.includes('Approve') && !btn.textContent?.includes('✓'));
+    fireEvent.click(submitApproveButton!);
+
+    await waitFor(() => {
+      expect(mockApproveRefundRequest).toHaveBeenCalledWith(
+        1,
+        'Refund approved',
+      );
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Success',
+        'Refund request approved successfully',
+      );
+      expect(mockGetAllRefundRequests).toHaveBeenCalled(); // Called at least once
+    });
+  });
+
+  it('denies refund with reason and reloads data', async () => {
+    const requests = [
+      {
+        id: 1,
+        eventName: 'Test Event',
+        userName: 'Test User',
+        status: 'pending',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ];
+
+    mockGetAllRefundRequests.mockResolvedValue(requests); // Will return requests for all calls
+    mockDenyRefundRequest.mockResolvedValue({ success: true });
+
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('✗ Deny'));
+    });
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, {
+        target: { value: 'Event already occurred' },
+      });
+    });
+
+    const denyButtons = screen.getAllByRole('button');
+    const submitDenyButton = denyButtons.find(btn => btn.textContent?.includes('Deny') && !btn.textContent?.includes('✗'));
+    fireEvent.click(submitDenyButton!);
+
+    await waitFor(() => {
+      expect(mockDenyRefundRequest).toHaveBeenCalledWith(
+        1,
+        'Event already occurred',
+      );
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Success',
+        'Refund request denied successfully',
+      );
+    });
+  });
+
+  it('displays processed refunds separately', async () => {
+    const requests = [
+      {
+        id: 1,
+        eventName: 'Pending Event',
+        userName: 'User 1',
+        status: 'pending',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+      {
+        id: 2,
+        eventName: 'Approved Event',
+        userName: 'User 2',
+        status: 'approved',
+        adminResponse: 'Refund processed',
+        processedAt: '2026-03-02T10:00:00Z',
+      },
+      {
+        id: 3,
+        eventName: 'Denied Event',
+        userName: 'User 3',
+        status: 'denied',
+        adminResponse: 'Too late',
+        processedAt: '2026-03-03T10:00:00Z',
+      },
+    ];
+
+    mockGetAllRefundRequests.mockResolvedValue(requests);
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Pending (1)')).toBeTruthy();
+      expect(screen.getByText('Recently Processed')).toBeTruthy();
+      expect(screen.getByText('Approved Event')).toBeTruthy();
+      expect(screen.getByText('Denied Event')).toBeTruthy();
+      expect(screen.getByText('APPROVED')).toBeTruthy();
+      expect(screen.getByText('DENIED')).toBeTruthy();
+    });
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockGetAllRefundRequests.mockRejectedValue(
+      new Error('Network error'),
+    );
+    render(<RefundRequestsScreen />);
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Error',
+        'Failed to load refund requests',
+      );
+    });
+  });
+
+  it('redirects non-admin users to home', () => {
+    const { useAuth } = require('../../src/frontend/mobile/app/_context/AuthContext');
+    (useAuth as jest.Mock).mockReturnValueOnce({ isAdmin: false });
+
+    render(<RefundRequestsScreen />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)');
+  });
+});

--- a/test/frontend/ticket-detail.test.tsx
+++ b/test/frontend/ticket-detail.test.tsx
@@ -1,0 +1,322 @@
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { Alert } from 'react-native';
+
+const mockGetUserTickets = jest.fn();
+const mockCreateRefundRequest = jest.fn();
+const mockCancelSignup = jest.fn();
+
+jest.mock('../../src/frontend/mobile/app/_lib/api', () => ({
+  getUserTickets: mockGetUserTickets,
+  createRefundRequest: mockCreateRefundRequest,
+  cancelSignup: mockCancelSignup,
+}));
+
+jest.mock('../../src/frontend/mobile/app/_context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 5, name: 'Test User' } }),
+}));
+
+import TicketDetailScreen from '../../src/frontend/mobile/app/ticket-detail';
+
+describe('TicketDetailScreen', () => {
+  const mockRouter = require('expo-router').__mockRouter;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    require('expo-router').__setParams({ ticketId: '1' });
+  });
+
+  it('renders loading state initially', () => {
+    mockGetUserTickets.mockReturnValue(new Promise(() => {}));
+    render(<TicketDetailScreen />);
+    expect(screen.getByRole('progressbar')).toBeTruthy();
+  });
+
+  it('displays ticket details for paid event', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Annual Gala 2026',
+        eventDate: '2026-06-15T19:00:00Z',
+        eventLocation: 'Grand Ballroom',
+        eventPrice: 5000,
+        tableSeat: 'Table 3, Seat 2',
+        busSeat: 'Bus 1 - Seat 10',
+        qrCodeData: 'TICKET:5:10:1:1234567890',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Annual Gala 2026')).toBeTruthy();
+      expect(screen.getByText('Grand Ballroom')).toBeTruthy();
+      expect(screen.getByText('$50.00')).toBeTruthy();
+      expect(screen.getByText('Table 3, Seat 2')).toBeTruthy();
+      expect(screen.getByText('Bus 1 - Seat 10')).toBeTruthy();
+    });
+  });
+
+  it('shows Request Refund button for paid events', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Test Event',
+        eventPrice: 2500,
+        qrCodeData: 'TICKET:5:10:1:123',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Request Refund')).toBeTruthy();
+    });
+  });
+
+  it('shows Cancel Sign-Up button for free events', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Free Event',
+        eventPrice: 0,
+        qrCodeData: 'TICKET:5:10:1:123',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cancel Sign-Up')).toBeTruthy();
+    });
+  });
+
+  it('opens refund modal when Request Refund clicked', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Paid Event',
+        eventPrice: 5000,
+        qrCodeData: 'TICKET:5:10:1:123',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      const buttons = screen.getAllByRole('button');
+      const refundButton = buttons.find(
+        (btn) => btn.textContent === 'Request Refund',
+      );
+      fireEvent.click(refundButton!);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('Reason for refund (required)'),
+      ).toBeTruthy();
+    });
+  });
+
+  it('validates required reason for refund request', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Test Event',
+        eventPrice: 5000,
+        qrCodeData: 'TICKET:5:10:1:123',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      const buttons = screen.getAllByRole('button');
+      const refundButton = buttons.find(btn => btn.textContent === 'Request Refund');
+      fireEvent.click(refundButton!);
+    });
+
+    await waitFor(() => {
+      const submitButton = screen.getAllByText('Submit Request')[0];
+      fireEvent.click(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Required',
+        'Please provide a reason for your refund request.',
+      );
+    });
+
+    expect(mockCreateRefundRequest).not.toHaveBeenCalled();
+  });
+
+  it('submits refund request with reason and reloads ticket', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Test Event',
+        eventPrice: 5000,
+        qrCodeData: 'TICKET:5:10:1:123',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    mockCreateRefundRequest.mockResolvedValue({ success: true, requestId: 10 });
+
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      const buttons = screen.getAllByRole('button');
+      const refundButton = buttons.find(
+        (btn) => btn.textContent === 'Request Refund',
+      );
+      fireEvent.click(refundButton!);
+    });
+
+    await waitFor(() => {
+      const input = screen.getByPlaceholderText('Reason for refund (required)');
+      fireEvent.change(input, {
+        target: { value: 'Cannot attend due to emergency' },
+      });
+    });
+
+    const submitButton = screen.getAllByText('Submit Request')[0];
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockCreateRefundRequest).toHaveBeenCalledWith(
+        1,
+        'Cannot attend due to emergency',
+      );
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Refund Requested',
+        'Your refund request has been submitted. An admin will review it shortly.',
+        expect.any(Array),
+      );
+      // Called at least once (initial load); we don't simulate the Alert "OK" press here
+      expect(mockGetUserTickets).toHaveBeenCalled();
+    });
+  });
+
+  it('displays refund pending status', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Test Event',
+        eventPrice: 5000,
+        qrCodeData: 'TICKET:5:10:1:123',
+        refundRequest: {
+          id: 10,
+          status: 'pending',
+          createdAt: '2026-03-01T10:00:00Z',
+        },
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    // Banner title
+    await screen.findByText('Refund Requested');
+    // Banner description text contains this phrase
+    expect(
+      screen.getByText(/pending admin review/i),
+    ).toBeTruthy();
+
+    // Should not show Request Refund button when pending
+    expect(screen.queryByText('Request Refund')).toBeNull();
+  });
+
+  it('displays refund denied status with admin response', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Test Event',
+        eventPrice: 5000,
+        qrCodeData: 'TICKET:5:10:1:123',
+        refundRequest: {
+          id: 10,
+          status: 'denied',
+          adminResponse: 'Event already occurred',
+          createdAt: '2026-03-01T10:00:00Z',
+        },
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Refund Denied')).toBeTruthy();
+      expect(screen.getByText('Event already occurred')).toBeTruthy();
+    });
+  });
+
+  it('cancels free event signup with confirmation', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventId: 10,
+        eventName: 'Free Event',
+        eventPrice: 0,
+        qrCodeData: 'TICKET:5:10:1:123',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    mockCancelSignup.mockResolvedValue({ cancelled: true });
+
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('Cancel Sign-Up'));
+    });
+
+    const confirmText = await screen.findByText((text: string) =>
+      text.startsWith(
+        'Are you sure you want to cancel your registration for this event?',
+      ),
+    );
+    expect(confirmText).toBeTruthy();
+    fireEvent.click(screen.getByText('Yes, Cancel'));
+
+    await waitFor(() => {
+      expect(mockCancelSignup).toHaveBeenCalledWith(10);
+    });
+
+    // Simulate user pressing "OK" on the success alert to trigger router.back()
+    const alertCall = (Alert.alert as jest.Mock).mock.calls[0];
+    const buttons = alertCall[2] as Array<{ text: string; onPress?: () => void }>;
+    const okButton = buttons.find((b) => b.text === 'OK');
+    okButton?.onPress?.();
+
+    expect(mockRouter.back).toHaveBeenCalled();
+  });
+
+  it('displays QR code for entry', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Test Event',
+        eventPrice: 0,
+        qrCodeData: 'TICKET:5:10:1:1234567890',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Entry QR Code')).toBeTruthy();
+      expect(
+        screen.getByText('Show this QR code at the event entrance'),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -647,6 +648,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -670,6 +672,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1347,6 +1350,7 @@
       "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -1693,6 +1697,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2038,6 +2043,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3657,6 +3663,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4815,6 +4822,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5507,6 +5515,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5520,6 +5529,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5540,7 +5550,8 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -5640,6 +5651,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6254,6 +6266,7 @@
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
- Implemented a new RefundRequestsService to handle the full refund lifecycle (create, approve, deny, list per user and for admins). 
- The service integrates with Stripe refunds where applicable, updates ticket/refund state, and preserves historical refund records even after tickets are deleted.
- Added mobile UI for users to request refunds from the ticket detail screen (with mandatory reason and proper keyboard handling) and for admins to review, approve, or deny requests.

### Test coverage: 
- Added comprehensive Jest tests for both backend and frontend:
- cover permission checks, request creation, Stripe refund initiation, ticket deletion behavior, and admin workflows.
- validate the refund list UI, modal behavior, required fields, error handling, navigation, and the user‑facing refund state on tickets.

closes #264 