### PR TITLE
[Feature] Admin Ticket QR Scanner

### DIFF
--- a/src/backend/src/events/events.controller.ts
+++ b/src/backend/src/events/events.controller.ts
@@ -16,13 +16,14 @@ import { EventsService } from './events.service';
 import type { NewEvent } from '../db/schema';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
 
 interface RequestWithUser extends Request {
   user: { sub: number; email: string };
 }
 
 @Controller('events')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class EventsController {
   constructor(
     private readonly eventsService: EventsService,
@@ -32,6 +33,12 @@ export class EventsController {
   @Get()
   findAll() {
     return this.eventsService.findAll();
+  }
+
+  @Post('check-in')
+  @Roles('Admin')
+  checkIn(@Body('qrCodeData') qrCodeData: string) {
+    return this.eventsService.checkInTicket(qrCodeData ?? '');
   }
 
   @Get(':id')

--- a/src/backend/src/events/events.service.ts
+++ b/src/backend/src/events/events.service.ts
@@ -9,6 +9,7 @@ import {
   busSeats,
   seatReservations,
   refundRequests,
+  users,
 } from '../db/schema';
 import type { NewEvent } from '../db/schema';
 import { eq, sql, and, asc } from 'drizzle-orm';
@@ -41,6 +42,116 @@ export class EventsService {
       .update(data)
       .digest('hex');
     return `${data}:${signature}`;
+  }
+
+  /**
+   * Verify QR code signature and return parsed data or null if invalid
+   */
+  private verifyQRCodeData(qrCodeData: string): {
+    ticketId: number;
+    userId: number;
+    eventId: number;
+  } | null {
+    const parts = qrCodeData.split(':');
+    if (parts.length !== 4) return null;
+    const [ticketIdStr, userIdStr, eventIdStr, signature] = parts;
+    const ticketId = parseInt(ticketIdStr, 10);
+    const userId = parseInt(userIdStr, 10);
+    const eventId = parseInt(eventIdStr, 10);
+    if (isNaN(ticketId) || isNaN(userId) || isNaN(eventId)) return null;
+    const data = `${ticketId}:${userId}:${eventId}`;
+    const secret =
+      process.env.QR_SECRET || 'default-secret-change-in-production';
+    const expectedSig = crypto
+      .createHmac('sha256', secret)
+      .update(data)
+      .digest('hex');
+    if (expectedSig !== signature) return null;
+    return { ticketId, userId, eventId };
+  }
+
+  /**
+   * Check in a ticket by scanning its QR code. Admin only.
+   * Returns ticket details on success, or error info.
+   */
+  async checkInTicket(qrCodeData: string): Promise<{
+    success: boolean;
+    alreadyCheckedIn?: boolean;
+    ticket?: {
+      ticketId: number;
+      eventName: string;
+      eventDate: string;
+      userName: string;
+      userEmail: string;
+      busSeat: string | null;
+      tableSeat: string | null;
+    };
+    error?: string;
+  }> {
+    if (!qrCodeData || typeof qrCodeData !== 'string') {
+      return { success: false, error: 'Invalid QR code data' };
+    }
+    const trimmed = qrCodeData.trim();
+    const parsed = this.verifyQRCodeData(trimmed);
+    if (!parsed) {
+      return { success: false, error: 'Invalid or tampered QR code' };
+    }
+    const { ticketId } = parsed;
+
+    const ticketRows = await this.dbService.db
+      .select({
+        ticketId: tickets.id,
+        checkedIn: tickets.checkedIn,
+        busSeat: tickets.busSeat,
+        tableSeat: tickets.tableSeat,
+        eventName: events.name,
+        eventDate: events.date,
+        userName: users.name,
+        userEmail: users.email,
+      })
+      .from(tickets)
+      .innerJoin(events, eq(tickets.eventId, events.id))
+      .innerJoin(users, eq(tickets.userId, users.id))
+      .where(eq(tickets.id, ticketId));
+
+    const row = ticketRows[0];
+    if (!row) {
+      return { success: false, error: 'Ticket not found' };
+    }
+    if (row.checkedIn) {
+      return {
+        success: false,
+        alreadyCheckedIn: true,
+        ticket: {
+          ticketId: row.ticketId,
+          eventName: row.eventName,
+          eventDate: String(row.eventDate),
+          userName: row.userName,
+          userEmail: row.userEmail,
+          busSeat: row.busSeat,
+          tableSeat: row.tableSeat,
+        },
+        error: 'Already checked in',
+      };
+    }
+
+    await this.dbService.db
+      .update(tickets)
+      .set({ checkedIn: true, updatedAt: new Date() })
+      .where(eq(tickets.id, ticketId));
+
+    return {
+      success: true,
+      ticket: {
+        ticketId: row.ticketId,
+        eventName: row.eventName,
+        eventDate: String(row.eventDate),
+        userName: row.userName,
+        userEmail: row.userEmail,
+        busSeat: row.busSeat,
+        tableSeat: row.tableSeat,
+      },
+    };
   }
 
   async findAll() {

--- a/src/frontend/mobile/app.json
+++ b/src/frontend/mobile/app.json
@@ -4,6 +4,14 @@
     "slug": "mobile",
     "version": "1.0.0",
     "scheme": "mobile",
+    "plugins": [
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Allow MacSync to access your camera to scan ticket QR codes"
+        }
+      ]
+    ],
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,

--- a/src/frontend/mobile/app/(tabs)/admin.tsx
+++ b/src/frontend/mobile/app/(tabs)/admin.tsx
@@ -47,23 +47,23 @@ export default function AdminScreen() {
             </Text>
           </Pressable>
 
-          {/* QR Scanner - Coming Soon */}
-          <View className="bg-white rounded-2xl p-6 border border-gray-100 shadow-sm opacity-60">
+          {/* QR Scanner */}
+          <Pressable
+            onPress={() => router.push("/qr-scanner")}
+            className="bg-white rounded-2xl p-6 border border-gray-100 shadow-sm active:bg-gray-50"
+          >
             <View className="flex-row items-start justify-between mb-3">
               <View className="w-12 h-12 bg-blue-100 rounded-xl items-center justify-center">
                 <Text className="text-2xl">📷</Text>
-              </View>
-              <View className="bg-gray-400 px-2 py-1 rounded-full">
-                <Text className="text-xs font-bold text-white">Soon</Text>
               </View>
             </View>
             <Text className="text-lg font-bold text-gray-900 mb-1">
               QR Code Scanner
             </Text>
             <Text className="text-sm text-gray-600">
-              Scan tickets at event entrance
+              Scan tickets at event entrance to check in attendees
             </Text>
-          </View>
+          </Pressable>
         </View>
       </ScrollView>
     </View>

--- a/src/frontend/mobile/app/(tabs)/my-tickets.tsx
+++ b/src/frontend/mobile/app/(tabs)/my-tickets.tsx
@@ -201,16 +201,23 @@ export default function MyTickets() {
 
                   {/* Content */}
                   <View className="flex-1 p-4">
-                    {/* Refund Status Badge */}
-                    {ticket.refundRequest && ticket.refundRequest.status === 'pending' && (
-                      <View className="mb-2">
-                        <View className="bg-yellow-100 px-3 py-1.5 rounded-lg self-start">
+                    {/* Status Badges */}
+                    <View className="flex-row flex-wrap gap-2 mb-2">
+                      {ticket.checkedIn && (
+                        <View className="bg-green-100 px-3 py-1.5 rounded-lg">
+                          <Text className="text-xs font-bold text-green-800">
+                            ✓ Checked In
+                          </Text>
+                        </View>
+                      )}
+                      {ticket.refundRequest && ticket.refundRequest.status === 'pending' && (
+                        <View className="bg-yellow-100 px-3 py-1.5 rounded-lg">
                           <Text className="text-xs font-bold text-yellow-800">
                             ⏳ Refund Pending
                           </Text>
                         </View>
-                      </View>
-                    )}
+                      )}
+                    </View>
 
                     <View className="flex-row items-start justify-between mb-2">
                       <View className="flex-1">

--- a/src/frontend/mobile/app/_lib/api.ts
+++ b/src/frontend/mobile/app/_lib/api.ts
@@ -341,3 +341,26 @@ export function denyRefundRequest(
     body: JSON.stringify({ adminResponse }),
   });
 }
+
+// ---------- Check-In (Admin) ----------
+export interface CheckInResult {
+  success: boolean;
+  alreadyCheckedIn?: boolean;
+  ticket?: {
+    ticketId: number;
+    eventName: string;
+    eventDate: string;
+    userName: string;
+    userEmail: string;
+    busSeat: string | null;
+    tableSeat: string | null;
+  };
+  error?: string;
+}
+
+export function checkInTicket(qrCodeData: string): Promise<CheckInResult> {
+  return apiFetch('/events/check-in', {
+    method: 'POST',
+    body: JSON.stringify({ qrCodeData }),
+  });
+}

--- a/src/frontend/mobile/app/qr-scanner.tsx
+++ b/src/frontend/mobile/app/qr-scanner.tsx
@@ -1,0 +1,307 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  ActivityIndicator,
+  StyleSheet,
+  Platform,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { CameraView, useCameraPermissions } from "expo-camera";
+import { useAuth } from "./_context/AuthContext";
+import { checkInTicket, type CheckInResult } from "./_lib/api";
+
+type ScanStatus = "idle" | "scanning" | "processing" | "success" | "already" | "error";
+
+export default function QRScannerScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { isAdmin } = useAuth();
+  const [permission, requestPermission] = useCameraPermissions();
+  const [status, setStatus] = useState<ScanStatus>("idle");
+  const [lastResult, setLastResult] = useState<CheckInResult | null>(null);
+  const isProcessingRef = useRef(false);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      router.replace("/(tabs)");
+      return;
+    }
+    if (permission?.granted) {
+      setStatus("scanning");
+      isProcessingRef.current = false;
+    } else if (permission?.canAskAgain) {
+      requestPermission().then((p) => {
+        if (p?.granted) {
+          setStatus("scanning");
+          isProcessingRef.current = false;
+        }
+      });
+    }
+  }, [isAdmin, permission, requestPermission, router]);
+
+  const handleBarcodeScanned = useCallback(
+    async (event: { data?: string; nativeEvent?: { data?: string } }) => {
+      const data = event?.data ?? event?.nativeEvent?.data;
+      if (!data) return;
+      if (isProcessingRef.current) return;
+      isProcessingRef.current = true;
+
+      setStatus("processing");
+      setLastResult(null);
+      try {
+        const result = await checkInTicket(data);
+        setLastResult(result);
+        if (result.success) {
+          setStatus("success");
+        } else if (result.alreadyCheckedIn) {
+          setStatus("already");
+        } else {
+          setStatus("error");
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Check-in failed";
+        setLastResult({ success: false, error: message });
+        setStatus("error");
+      } finally {
+        isProcessingRef.current = false;
+      }
+    },
+    [],
+  );
+
+  const resetScan = () => {
+    isProcessingRef.current = false;
+    setStatus("scanning");
+    setLastResult(null);
+  };
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  if (Platform.OS === "web") {
+    return (
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <View className="px-4 py-6">
+          <Text className="text-xl font-bold text-gray-900 mb-2">
+            QR Code Scanner
+          </Text>
+          <Text className="text-gray-600 mb-4">
+            QR code scanning is only available on iOS and Android devices.
+            Please open this app on your phone to scan tickets at the event entrance.
+          </Text>
+          <Pressable
+            onPress={() => router.back()}
+            className="bg-gray-900 py-3 px-4 rounded-xl"
+          >
+            <Text className="text-white font-semibold text-center">Go Back</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
+  if (!permission) {
+    return (
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <ActivityIndicator size="large" />
+        <Text className="text-gray-600 mt-4">Checking camera permission…</Text>
+      </View>
+    );
+  }
+
+  if (!permission.granted) {
+    return (
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <Text className="text-lg font-semibold text-gray-900 mb-2">
+          Camera access required
+        </Text>
+        <Text className="text-gray-600 text-center mb-6">
+          Allow camera access to scan ticket QR codes at the event entrance.
+        </Text>
+        <Pressable
+          onPress={() => requestPermission()}
+          className="bg-blue-600 py-3 px-6 rounded-xl"
+        >
+          <Text className="text-white font-semibold">Allow Camera</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => router.back()}
+          className="mt-4 py-2"
+        >
+          <Text className="text-gray-600">Go Back</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      <View style={StyleSheet.absoluteFill}>
+        <CameraView
+          style={StyleSheet.absoluteFill}
+          facing="back"
+          barcodeScannerSettings={{ barcodeTypes: ["qr"] }}
+          onBarcodeScanned={
+            status === "scanning" ? handleBarcodeScanned : undefined
+          }
+        />
+      </View>
+
+      {/* Overlay */}
+      <View
+        style={[
+          styles.overlay,
+          {
+            top: insets.top,
+            bottom: insets.bottom + 120,
+          },
+        ]}
+        pointerEvents="none"
+      >
+        <View style={styles.scanFrame} />
+      </View>
+
+      {/* Top bar */}
+      <View
+        style={[
+          styles.topBar,
+          { paddingTop: insets.top + 8 },
+        ]}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          className="w-10 h-10 rounded-full bg-black/50 items-center justify-center"
+        >
+          <Text className="text-white text-lg">←</Text>
+        </Pressable>
+        <Text className="text-white font-semibold text-lg">Scan Ticket</Text>
+        <View style={{ width: 40 }} />
+      </View>
+
+      {/* Status / result panel */}
+      <View
+        style={[
+          styles.bottomPanel,
+          {
+            paddingBottom: insets.bottom + 16,
+          },
+        ]}
+      >
+        {status === "processing" && (
+          <View className="bg-white/95 rounded-2xl p-6 items-center">
+            <ActivityIndicator size="large" />
+            <Text className="text-gray-700 mt-3 font-medium">
+              Verifying ticket…
+            </Text>
+          </View>
+        )}
+
+        {status === "success" && lastResult?.ticket && (
+          <View className="bg-green-500/95 rounded-2xl p-6">
+            <Text className="text-white text-xl font-bold mb-2">✓ Checked In</Text>
+            <Text className="text-white font-medium">{lastResult.ticket.userName}</Text>
+            <Text className="text-white/90 text-sm">{lastResult.ticket.userEmail}</Text>
+            <Text className="text-white/90 text-sm mt-1">{lastResult.ticket.eventName}</Text>
+            {lastResult.ticket.tableSeat && (
+              <Text className="text-white/80 text-sm">Table: {lastResult.ticket.tableSeat}</Text>
+            )}
+            {lastResult.ticket.busSeat && (
+              <Text className="text-white/80 text-sm">Bus: {lastResult.ticket.busSeat}</Text>
+            )}
+          </View>
+        )}
+
+        {status === "already" && lastResult?.ticket && (
+          <View className="bg-amber-500/95 rounded-2xl p-6">
+            <Text className="text-white text-xl font-bold mb-2">Already Checked In</Text>
+            <Text className="text-white font-medium">{lastResult.ticket.userName}</Text>
+            <Text className="text-white/90 text-sm">{lastResult.ticket.userEmail}</Text>
+            <Text className="text-white/90 text-sm mt-1">{lastResult.ticket.eventName}</Text>
+            {lastResult.ticket.tableSeat && (
+              <Text className="text-white/80 text-sm">Table: {lastResult.ticket.tableSeat}</Text>
+            )}
+            {lastResult.ticket.busSeat && (
+              <Text className="text-white/80 text-sm">Bus: {lastResult.ticket.busSeat}</Text>
+            )}
+          </View>
+        )}
+
+        {status === "error" && (
+          <View className="bg-red-500/95 rounded-2xl p-6">
+            <Text className="text-white text-xl font-bold mb-2">Invalid Ticket</Text>
+            <Text className="text-white/90">
+              {lastResult?.error ?? "Could not validate this QR code."}
+            </Text>
+          </View>
+        )}
+
+        {status === "scanning" && (
+          <View className="bg-black/60 rounded-2xl px-6 py-4">
+            <Text className="text-white text-center font-medium">
+              Point camera at ticket QR code
+            </Text>
+            <Text className="text-white/80 text-sm text-center mt-1">
+              Scan one ticket at a time
+            </Text>
+          </View>
+        )}
+
+        {(status === "success" || status === "already" || status === "error") && (
+          <Pressable
+            onPress={resetScan}
+            className="mt-4 bg-white py-4 px-8 rounded-xl border-2 border-white/80 active:bg-gray-100"
+          >
+            <Text className="text-gray-900 font-bold text-center text-base">
+              Scan next ticket
+            </Text>
+            <Text className="text-gray-600 text-sm text-center mt-1">
+              Tap to continue
+            </Text>
+          </Pressable>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000",
+  },
+  overlay: {
+    position: "absolute",
+    left: 24,
+    right: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  scanFrame: {
+    width: 260,
+    height: 260,
+    borderWidth: 2,
+    borderColor: "rgba(255,255,255,0.6)",
+    borderRadius: 16,
+    backgroundColor: "transparent",
+  },
+  topBar: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+  },
+  bottomPanel: {
+    position: "absolute",
+    left: 24,
+    right: 24,
+    bottom: 0,
+    alignItems: "center",
+  },
+});

--- a/src/frontend/mobile/app/ticket-detail.tsx
+++ b/src/frontend/mobile/app/ticket-detail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -13,6 +13,7 @@ import {
   TouchableWithoutFeedback,
 } from "react-native";
 import { useLocalSearchParams, router } from "expo-router";
+import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import QRCode from "react-native-qrcode-svg";
 import { getUserTickets, createRefundRequest, cancelSignup, type Ticket } from "./_lib/api";
@@ -33,6 +34,12 @@ export default function TicketDetailScreen() {
   useEffect(() => {
     loadTicket();
   }, [ticketId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (user && ticketId) loadTicket();
+    }, [user, ticketId]),
+  );
 
   const loadTicket = async () => {
     if (!user || !ticketId) return;
@@ -322,11 +329,21 @@ export default function TicketDetailScreen() {
 
         {/* QR Code Card */}
         <View className="bg-white rounded-2xl p-6 items-center border border-gray-100 shadow-sm">
+          {ticket.checkedIn && (
+            <View className="mb-4 w-full bg-green-50 border border-green-200 rounded-xl px-4 py-3 flex-row items-center gap-2">
+              <Text className="text-lg">✓</Text>
+              <Text className="text-base font-semibold text-green-800">
+                Checked In
+              </Text>
+            </View>
+          )}
           <Text className="text-lg font-bold text-gray-900 mb-2">
             Entry QR Code
           </Text>
           <Text className="text-sm text-gray-500 text-center mb-6">
-            Show this QR code at the event entrance
+            {ticket.checkedIn
+              ? "You've been checked in. Welcome to the event!"
+              : "Show this QR code at the event entrance"}
           </Text>
 
           {ticket.qrCodeData ? (

--- a/src/frontend/mobile/package-lock.json
+++ b/src/frontend/mobile/package-lock.json
@@ -11,6 +11,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "expo": "~52.0.0",
         "expo-asset": "~10.0.0",
+        "expo-camera": "~16.0.18",
         "expo-constants": "~17.0.0",
         "expo-linking": "~7.0.0",
         "expo-router": "~4.0.0",
@@ -6331,6 +6332,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/expo-camera": {
+      "version": "16.0.18",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.0.18.tgz",
+      "integrity": "sha512-NP5u2yyc+wZc9GdUXH+jcEytyXZwBnHxItMwXoZQQxi4wgltwvs4XfSWjBtRZe1LngnhpBfPyPJV0aShjWlLDg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-constants": {
       "version": "17.0.8",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz",
@@ -10540,6 +10561,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.19.13.tgz",
       "integrity": "sha512-etv3bN8rJglrRCp/uL4p7l8QvUNUC++QwDbdZ8CB7BvZiMvsxfFIRM1j04vxNldG3uo2puRd6OSWR3ibtmc29A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",

--- a/src/frontend/mobile/package.json
+++ b/src/frontend/mobile/package.json
@@ -12,6 +12,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "expo": "~52.0.0",
     "expo-asset": "~10.0.0",
+    "expo-camera": "~16.0.18",
     "expo-constants": "~17.0.0",
     "expo-linking": "~7.0.0",
     "expo-router": "~4.0.0",

--- a/test/backend/events.controller.spec.ts
+++ b/test/backend/events.controller.spec.ts
@@ -38,6 +38,7 @@ describe('EventsController', () => {
       getTicketsForUser: jest.fn(),
       createCheckoutSession: jest.fn(),
       releaseReservation: jest.fn(),
+      checkInTicket: jest.fn(),
     };
     mockUsersService = { findOneWithRoles: jest.fn() };
     controller = new EventsController(mockEventsService, mockUsersService);
@@ -114,5 +115,29 @@ describe('EventsController', () => {
   it('releaseCheckoutReservation delegates to service', async () => {
     mockEventsService.releaseReservation.mockResolvedValue(undefined);
     expect(await controller.releaseCheckoutReservation('cs_123')).toEqual({ released: true });
+  });
+
+  it('checkIn passes qrCodeData to service and returns result', async () => {
+    const qrData = '1:5:10:abc123valid';
+    const result = {
+      success: true,
+      ticket: {
+        ticketId: 1,
+        eventName: 'Gala',
+        userName: 'Alice',
+        userEmail: 'alice@test.com',
+      },
+    };
+    mockEventsService.checkInTicket.mockResolvedValue(result);
+
+    expect(await controller.checkIn(qrData)).toEqual(result);
+    expect(mockEventsService.checkInTicket).toHaveBeenCalledWith(qrData);
+  });
+
+  it('checkIn passes empty string when qrCodeData is undefined', async () => {
+    mockEventsService.checkInTicket.mockResolvedValue({ success: false, error: 'Invalid QR code data' });
+
+    await controller.checkIn(undefined as any);
+    expect(mockEventsService.checkInTicket).toHaveBeenCalledWith('');
   });
 });

--- a/test/backend/events.service.spec.ts
+++ b/test/backend/events.service.spec.ts
@@ -9,6 +9,7 @@ jest.mock('../../src/backend/src/payments/payments.service', () => ({
 jest.mock('../../src/backend/src/db/schema', () => ({
   events: { id: 'events.id', name: 'events.name', date: 'events.date', price: 'events.price', imageUrl: 'events.imageUrl' },
   tickets: { id: 'tickets.id', eventId: 'tickets.eventId', userId: 'tickets.userId', checkedIn: 'tickets.checkedIn', busSeat: 'tickets.busSeat', tableSeat: 'tickets.tableSeat', qrCodeData: 'tickets.qrCodeData', createdAt: 'tickets.createdAt' },
+  users: { id: 'users.id', name: 'users.name', email: 'users.email' },
   tableSeats: { id: 'tableSeats.id', eventId: 'tableSeats.eventId' },
   busSeats: { id: 'busSeats.id', eventId: 'busSeats.eventId' },
   seatReservations: { id: 'seatReservations.id' },
@@ -143,5 +144,106 @@ describe('EventsService', () => {
     mockDb.delete.mockReturnValue(createDbChain());
     await service.releaseReservation('cs_test_123');
     expect(mockDb.delete).toHaveBeenCalled();
+  });
+
+  describe('checkInTicket', () => {
+    function makeValidQR(ticketId: number, userId: number, eventId: number): string {
+      const crypto = require('crypto');
+      const data = `${ticketId}:${userId}:${eventId}`;
+      const secret = process.env.QR_SECRET || 'default-secret-change-in-production';
+      const sig = crypto.createHmac('sha256', secret).update(data).digest('hex');
+      return `${data}:${sig}`;
+    }
+
+    it('returns error for empty or invalid qrCodeData', async () => {
+      expect(await service.checkInTicket('')).toEqual({
+        success: false,
+        error: 'Invalid QR code data',
+      });
+      expect(await service.checkInTicket('  ')).toEqual({
+        success: false,
+        error: 'Invalid or tampered QR code',
+      });
+      expect(await service.checkInTicket('invalid')).toEqual({
+        success: false,
+        error: 'Invalid or tampered QR code',
+      });
+      expect(await service.checkInTicket('1:2:3:bad-signature')).toEqual({
+        success: false,
+        error: 'Invalid or tampered QR code',
+      });
+    });
+
+    it('returns error when ticket not found', async () => {
+      const qr = makeValidQR(999, 5, 10);
+      mockDb.select.mockReturnValue(createDbChain([]));
+
+      const result = await service.checkInTicket(qr);
+
+      expect(result).toEqual({ success: false, error: 'Ticket not found' });
+    });
+
+    it('returns alreadyCheckedIn when ticket already checked in', async () => {
+      const qr = makeValidQR(1, 5, 10);
+      const row = {
+        ticketId: 1,
+        checkedIn: true,
+        eventName: 'Gala',
+        eventDate: new Date('2026-06-15'),
+        userName: 'Alice',
+        userEmail: 'alice@test.com',
+        busSeat: null,
+        tableSeat: 'Table 3',
+      };
+      mockDb.select.mockReturnValue(createDbChain([row]));
+
+      const result = await service.checkInTicket(qr);
+
+      expect(result).toMatchObject({
+        success: false,
+        alreadyCheckedIn: true,
+        error: 'Already checked in',
+        ticket: {
+          ticketId: 1,
+          eventName: 'Gala',
+          userName: 'Alice',
+          userEmail: 'alice@test.com',
+          busSeat: null,
+          tableSeat: 'Table 3',
+        },
+      });
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('checks in ticket successfully and updates database', async () => {
+      const qr = makeValidQR(1, 5, 10);
+      const row = {
+        ticketId: 1,
+        checkedIn: false,
+        eventName: 'Gala',
+        eventDate: new Date('2026-06-15'),
+        userName: 'Alice',
+        userEmail: 'alice@test.com',
+        busSeat: 'Bus 1 - Seat 5',
+        tableSeat: null,
+      };
+      mockDb.select.mockReturnValue(createDbChain([row]));
+      mockDb.update.mockReturnValue(createDbChain());
+
+      const result = await service.checkInTicket(qr);
+
+      expect(result).toMatchObject({
+        success: true,
+        ticket: {
+          ticketId: 1,
+          eventName: 'Gala',
+          userName: 'Alice',
+          userEmail: 'alice@test.com',
+          busSeat: 'Bus 1 - Seat 5',
+          tableSeat: null,
+        },
+      });
+      expect(mockDb.update).toHaveBeenCalled();
+    });
   });
 });

--- a/test/frontend/__mocks__/expo-camera.js
+++ b/test/frontend/__mocks__/expo-camera.js
@@ -1,0 +1,26 @@
+const React = require('react');
+const { View, Pressable, Text } = require('react-native');
+
+module.exports.CameraView = ({ style, children, onBarcodeScanned, ...props }) => {
+  return React.createElement(
+    View,
+    { ...props, style, testID: 'camera-view' },
+    children,
+    onBarcodeScanned &&
+      React.createElement(
+        Pressable,
+        {
+          testID: 'mock-scan-trigger',
+          onPress: () =>
+            onBarcodeScanned({ data: '1:5:10:mock-signature', nativeEvent: { data: '1:5:10:mock-signature' } }),
+        },
+        React.createElement(Text, {}, 'Mock Scan'),
+      ),
+  );
+};
+
+module.exports.useCameraPermissions = () => [
+  { granted: true, canAskAgain: false },
+  () => Promise.resolve({ granted: true }),
+  () => Promise.resolve({ granted: true }),
+];

--- a/test/frontend/jest.config.js
+++ b/test/frontend/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
     '^react-native$': '<rootDir>/test/frontend/__mocks__/react-native.js',
     '^react-native/(.*)$': '<rootDir>/test/frontend/__mocks__/react-native.js',
     '^react-native-qrcode-svg$': '<rootDir>/test/frontend/__mocks__/react-native-qrcode-svg.js',
+    '^expo-camera$': '<rootDir>/test/frontend/__mocks__/expo-camera.js',
     '^expo-router$': '<rootDir>/test/frontend/__mocks__/expo-router.js',
     '^react-native-safe-area-context$':
       '<rootDir>/test/frontend/__mocks__/react-native-safe-area-context.js',

--- a/test/frontend/qr-scanner.test.tsx
+++ b/test/frontend/qr-scanner.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+
+const mockReplace = jest.fn();
+const mockBack = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn(), back: mockBack }),
+}));
+
+const mockCheckInTicket = jest.fn();
+jest.mock('../../src/frontend/mobile/app/_lib/api', () => ({
+  checkInTicket: (...args: unknown[]) => mockCheckInTicket(...args),
+}));
+
+const mockUseAuth = jest.fn(() => ({ isAdmin: true }));
+jest.mock('../../src/frontend/mobile/app/_context/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import QRScannerScreen from '../../src/frontend/mobile/app/qr-scanner';
+
+describe('QRScannerScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects when not admin', () => {
+    mockUseAuth.mockReturnValue({ isAdmin: false });
+    render(<QRScannerScreen />);
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)');
+  });
+
+  it('shows scanning UI when admin with camera permission', async () => {
+    mockUseAuth.mockReturnValue({ isAdmin: true });
+    render(<QRScannerScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Point camera at ticket QR code')).toBeTruthy();
+      expect(screen.getByText('Scan one ticket at a time')).toBeTruthy();
+    });
+  });
+
+  it('calls checkInTicket when scan trigger is clicked', async () => {
+    mockUseAuth.mockReturnValue({ isAdmin: true });
+    mockCheckInTicket.mockResolvedValue({ success: false, error: 'test' });
+
+    render(<QRScannerScreen />);
+
+    await waitFor(() => expect(screen.getByTestId('mock-scan-trigger')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('mock-scan-trigger'));
+
+    await waitFor(() => {
+      expect(mockCheckInTicket).toHaveBeenCalledWith('1:5:10:mock-signature');
+    });
+  });
+
+});

--- a/test/frontend/ticket-detail.test.tsx
+++ b/test/frontend/ticket-detail.test.tsx
@@ -58,6 +58,26 @@ describe('TicketDetailScreen', () => {
     });
   });
 
+  it('shows Checked In badge when ticket is checked in', async () => {
+    const tickets = [
+      {
+        ticketId: 1,
+        eventName: 'Gala',
+        eventPrice: 5000,
+        checkedIn: true,
+        qrCodeData: 'TICKET:5:10:1:123',
+      },
+    ];
+
+    mockGetUserTickets.mockResolvedValue(tickets);
+    render(<TicketDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Checked In')).toBeTruthy();
+      expect(screen.getByText("You've been checked in. Welcome to the event!")).toBeTruthy();
+    });
+  });
+
   it('shows Request Refund button for paid events', async () => {
     const tickets = [
       {


### PR DESCRIPTION
- Adds an admin-only QR scanner so staff can scan ticket QR codes at the door and check attendees in. 
- Backend adds a secure check-in endpoint that validates the QR and updates the ticket; 
- the mobile app gets a full-screen scanner (expo-camera) with clear success / already checked in / error states and a “Scan next ticket” flow to avoid double scans. 
- Attendees see a “Checked In” badge on their ticket detail and in My Tickets. 
- Includes backend and frontend unit tests.