### PR TITLE
[SL-263] Payment Service Test Suite

### DIFF
--- a/test/backend/__mocks__/stripe.js
+++ b/test/backend/__mocks__/stripe.js
@@ -1,0 +1,16 @@
+const mockRefundsCreate = jest.fn().mockResolvedValue({ status: 'succeeded' });
+
+const mockStripeInstance = {
+  products: { create: jest.fn() },
+  prices: { create: jest.fn() },
+  checkout: { sessions: { create: jest.fn() } },
+  paymentIntents: { retrieve: jest.fn() },
+  refunds: { create: mockRefundsCreate },
+};
+
+function Stripe() {
+  return mockStripeInstance;
+}
+
+Stripe.mockRefundsCreate = mockRefundsCreate;
+module.exports = Stripe;

--- a/test/backend/events.controller.spec.ts
+++ b/test/backend/events.controller.spec.ts
@@ -112,6 +112,49 @@ describe('EventsController', () => {
     await expect(controller.getUserTickets('5', userReq)).rejects.toThrow('Access denied.');
   });
 
+  it('createCheckoutSession passes event id, user id, urls and optional selectedTable', async () => {
+    mockEventsService.createCheckoutSession.mockResolvedValue({
+      url: 'https://checkout.stripe.com/session',
+      sessionId: 'cs_test_123',
+    });
+    const req = { user: { sub: 5 } } as any;
+    const body = {
+      successUrl: 'https://app.example/payment-success',
+      cancelUrl: 'https://app.example/payment-cancel',
+    };
+
+    const result = await controller.createCheckoutSession('10', req, body);
+
+    expect(result).toEqual({ url: 'https://checkout.stripe.com/session', sessionId: 'cs_test_123' });
+    expect(mockEventsService.createCheckoutSession).toHaveBeenCalledWith(
+      10,
+      5,
+      'https://app.example/payment-success',
+      'https://app.example/payment-cancel',
+      undefined,
+    );
+  });
+
+  it('createCheckoutSession passes selectedTable when provided', async () => {
+    mockEventsService.createCheckoutSession.mockResolvedValue({ sessionId: 'cs_1' });
+    const req = { user: { sub: 3 } } as any;
+    const body = {
+      successUrl: 'https://x/s',
+      cancelUrl: 'https://x/c',
+      selectedTable: 2,
+    };
+
+    await controller.createCheckoutSession('1', req, body);
+
+    expect(mockEventsService.createCheckoutSession).toHaveBeenCalledWith(
+      1,
+      3,
+      'https://x/s',
+      'https://x/c',
+      2,
+    );
+  });
+
   it('releaseCheckoutReservation delegates to service', async () => {
     mockEventsService.releaseReservation.mockResolvedValue(undefined);
     expect(await controller.releaseCheckoutReservation('cs_123')).toEqual({ released: true });

--- a/test/backend/events.service.spec.ts
+++ b/test/backend/events.service.spec.ts
@@ -45,6 +45,7 @@ function createDbChain(result: any = []) {
 describe('EventsService', () => {
   let service: EventsService;
   let mockDb: any;
+  let mockPaymentsService: any;
 
   beforeEach(() => {
     mockDb = {
@@ -53,7 +54,11 @@ describe('EventsService', () => {
       update: jest.fn(),
       delete: jest.fn(),
     };
-    service = new EventsService({ db: mockDb } as any, {} as any);
+    mockPaymentsService = {
+      createCheckoutSession: jest.fn(),
+      recordPayment: jest.fn(),
+    };
+    service = new EventsService({ db: mockDb } as any, mockPaymentsService);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -144,6 +149,210 @@ describe('EventsService', () => {
     mockDb.delete.mockReturnValue(createDbChain());
     await service.releaseReservation('cs_test_123');
     expect(mockDb.delete).toHaveBeenCalled();
+  });
+
+  describe('createCheckoutSession (payment flow)', () => {
+    it('returns error when event not found', async () => {
+      mockDb.select.mockReturnValue(createDbChain([]));
+
+      const result = await service.createCheckoutSession(
+        999,
+        1,
+        'https://app/success',
+        'https://app/cancel',
+      );
+
+      expect(result).toEqual({ error: 'Event not found' });
+      expect(mockPaymentsService.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('returns error when event has price but no Stripe price configured', async () => {
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, name: 'Gala', price: 5000, stripePriceId: null, capacity: 100, requiresTableSignup: false }]))
+        .mockReturnValueOnce(createDbChain([{ count: 0 }]))
+        .mockReturnValueOnce(createDbChain([]));
+
+      const result = await service.createCheckoutSession(
+        1,
+        1,
+        'https://app/success',
+        'https://app/cancel',
+      );
+
+      expect(result).toEqual({
+        error: 'This event requires payment but has no Stripe price configured.',
+      });
+      expect(mockPaymentsService.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('returns error when event is full', async () => {
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, name: 'Gala', price: 5000, stripePriceId: 'price_1', capacity: 10, requiresTableSignup: false }]))
+        .mockReturnValueOnce(createDbChain([{ count: 10 }]));
+
+      const result = await service.createCheckoutSession(
+        1,
+        1,
+        'https://app/success',
+        'https://app/cancel',
+      );
+
+      expect(result).toEqual({ error: 'Event is full' });
+      expect(mockPaymentsService.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('returns error when user already signed up', async () => {
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, name: 'Gala', price: 5000, stripePriceId: 'price_1', capacity: 10, requiresTableSignup: false }]))
+        .mockReturnValueOnce(createDbChain([{ count: 5 }]))
+        .mockReturnValueOnce(createDbChain([{ id: 1, userId: 1, eventId: 1 }]));
+
+      const result = await service.createCheckoutSession(
+        1,
+        1,
+        'https://app/success',
+        'https://app/cancel',
+      );
+
+      expect(result).toEqual({ error: 'Already signed up for this event' });
+      expect(mockPaymentsService.createCheckoutSession).not.toHaveBeenCalled();
+    });
+
+    it('calls paymentsService.createCheckoutSession and inserts reservation on success', async () => {
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, name: 'Gala', price: 5000, stripePriceId: 'price_1', capacity: 10, requiresTableSignup: false }]))
+        .mockReturnValueOnce(createDbChain([{ count: 5 }]))
+        .mockReturnValueOnce(createDbChain([]));
+      mockDb.delete.mockReturnValue(createDbChain());
+      mockPaymentsService.createCheckoutSession.mockResolvedValue({
+        url: 'https://checkout.stripe.com/session',
+        sessionId: 'cs_test_123',
+      });
+      const tx = {
+        insert: jest.fn().mockReturnValue({ values: jest.fn().mockReturnValue(createDbChain()) }),
+      };
+      mockDb.transaction = jest.fn().mockImplementation((cb: (tx: any) => Promise<any>) =>
+        cb(tx),
+      );
+
+      const result = await service.createCheckoutSession(
+        1,
+        5,
+        'https://app/success',
+        'https://app/cancel',
+      );
+
+      expect(result).toEqual({ url: 'https://checkout.stripe.com/session', sessionId: 'cs_test_123' });
+      expect(mockPaymentsService.createCheckoutSession).toHaveBeenCalledWith({
+        eventId: 1,
+        userId: 5,
+        amount: 5000,
+        currency: 'usd',
+        eventName: 'Gala',
+        successUrl: 'https://app/success',
+        cancelUrl: 'https://app/cancel',
+      });
+      expect(tx.insert).toHaveBeenCalled();
+    });
+
+    it('returns error when paymentsService.createCheckoutSession returns error', async () => {
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, name: 'Gala', price: 5000, stripePriceId: 'price_1', capacity: 10, requiresTableSignup: false }]))
+        .mockReturnValueOnce(createDbChain([{ count: 5 }]))
+        .mockReturnValueOnce(createDbChain([]));
+      mockDb.delete.mockReturnValue(createDbChain());
+      mockPaymentsService.createCheckoutSession.mockResolvedValue({
+        error: 'Payment service is not configured.',
+      });
+      const tx = {
+        insert: jest.fn().mockReturnValue({ values: jest.fn().mockReturnValue(createDbChain()) }),
+      };
+      mockDb.transaction = jest.fn().mockImplementation((cb: (tx: any) => Promise<any>) =>
+        cb(tx),
+      );
+
+      const result = await service.createCheckoutSession(
+        1,
+        5,
+        'https://app/success',
+        'https://app/cancel',
+      );
+
+      expect(result).toEqual({ error: 'Payment service is not configured.' });
+      expect(tx.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('completeSignupFromReservation (payment flow)', () => {
+    it('returns error when reservation not found', async () => {
+      mockDb.select.mockReturnValue(createDbChain([]));
+
+      const result = await service.completeSignupFromReservation('cs_unknown');
+
+      expect(result).toEqual({ error: 'Reservation not found or already used' });
+      expect(mockPaymentsService.recordPayment).not.toHaveBeenCalled();
+    });
+
+    it('returns error when user already has ticket for event', async () => {
+      const reservation = { id: 1, stripeSessionId: 'cs_123', eventId: 10, userId: 5, tableSeatId: null, busSeatId: null };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([reservation]))
+        .mockReturnValueOnce(createDbChain([{ id: 1, userId: 5, eventId: 10 }]));
+      mockDb.delete.mockReturnValue(createDbChain());
+
+      const result = await service.completeSignupFromReservation('cs_123');
+
+      expect(result).toEqual({ error: 'Already signed up for this event', ticket: { id: 1, userId: 5, eventId: 10 } });
+      expect(mockPaymentsService.recordPayment).not.toHaveBeenCalled();
+    });
+
+    it('creates ticket and calls recordPayment when paymentData provided', async () => {
+      const reservation = { id: 1, stripeSessionId: 'cs_123', eventId: 10, userId: 5, tableSeatId: null, busSeatId: null };
+      const newTicket = { id: 99, userId: 5, eventId: 10, qrCodeData: null, tableSeat: null, busSeat: null };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([reservation]))
+        .mockReturnValueOnce(createDbChain([]));
+      mockDb.insert.mockReturnValue(createDbChain([newTicket]));
+      mockDb.update.mockReturnValue(createDbChain());
+      mockDb.delete.mockReturnValue(createDbChain());
+
+      const result = await service.completeSignupFromReservation('cs_123', {
+        paymentIntentId: 'pi_1',
+        chargeId: 'ch_1',
+        amountPaid: 5000,
+        currency: 'usd',
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.ticket).toMatchObject({ id: 99, userId: 5, eventId: 10 });
+      expect(mockPaymentsService.recordPayment).toHaveBeenCalledWith({
+        userId: 5,
+        eventId: 10,
+        ticketId: 99,
+        stripeSessionId: 'cs_123',
+        paymentIntentId: 'pi_1',
+        chargeId: 'ch_1',
+        amountPaid: 5000,
+        currency: 'usd',
+      });
+    });
+
+    it('does not call recordPayment when paymentData omitted', async () => {
+      const reservation = { id: 1, stripeSessionId: 'cs_123', eventId: 10, userId: 5, tableSeatId: null, busSeatId: null };
+      const newTicket = { id: 99, userId: 5, eventId: 10, qrCodeData: null, tableSeat: null, busSeat: null };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([reservation]))
+        .mockReturnValueOnce(createDbChain([]));
+      mockDb.insert.mockReturnValue(createDbChain([newTicket]));
+      mockDb.update.mockReturnValue(createDbChain());
+      mockDb.delete.mockReturnValue(createDbChain());
+
+      const result = await service.completeSignupFromReservation('cs_123');
+
+      expect(result.error).toBeUndefined();
+      expect(result.ticket).toMatchObject({ id: 99 });
+      expect(mockPaymentsService.recordPayment).not.toHaveBeenCalled();
+    });
   });
 
   describe('checkInTicket', () => {

--- a/test/backend/jest.config.js
+++ b/test/backend/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
   moduleNameMapper: {
     '^drizzle-orm$': '<rootDir>/test/backend/__mocks__/drizzle-orm.js',
     '^drizzle-orm/(.*)$': '<rootDir>/test/backend/__mocks__/drizzle-orm.js',
+    '^stripe$': '<rootDir>/test/backend/__mocks__/stripe.js',
   },
   modulePaths: ['<rootDir>/test/node_modules'],
   collectCoverageFrom: [

--- a/test/backend/payments.controller.spec.ts
+++ b/test/backend/payments.controller.spec.ts
@@ -1,0 +1,78 @@
+import 'reflect-metadata';
+
+jest.mock('../../src/backend/src/payments/payments.service', () => ({
+  PaymentsService: jest.fn(),
+}));
+jest.mock('../../src/backend/src/db/schema', () => ({}));
+
+import { PaymentsController } from '../../src/backend/src/payments/payments.controller';
+
+describe('PaymentsController', () => {
+  let controller: PaymentsController;
+  let mockPaymentsService: any;
+
+  beforeEach(() => {
+    mockPaymentsService = {
+      refundPayment: jest.fn(),
+      getPaymentsByUser: jest.fn(),
+      getPaymentsByEvent: jest.fn(),
+    };
+    controller = new PaymentsController(mockPaymentsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('refundPayment', () => {
+    it('calls service with paymentId, adminUserId, and optional partialAmount', async () => {
+      mockPaymentsService.refundPayment.mockResolvedValue({ success: true });
+
+      const result = await controller.refundPayment('10', {
+        adminUserId: 1,
+        partialAmount: 2000,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockPaymentsService.refundPayment).toHaveBeenCalledWith(
+        10,
+        1,
+        2000,
+      );
+    });
+
+    it('passes undefined partialAmount when not in body', async () => {
+      mockPaymentsService.refundPayment.mockResolvedValue({ success: true });
+
+      await controller.refundPayment('5', { adminUserId: 2 });
+
+      expect(mockPaymentsService.refundPayment).toHaveBeenCalledWith(
+        5,
+        2,
+        undefined,
+      );
+    });
+  });
+
+  describe('getUserPayments', () => {
+    it('returns payments for user', async () => {
+      const payments = [{ id: 1, userId: 5, amountPaid: 5000 }];
+      mockPaymentsService.getPaymentsByUser.mockResolvedValue(payments);
+
+      const result = await controller.getUserPayments('5');
+
+      expect(result).toEqual(payments);
+      expect(mockPaymentsService.getPaymentsByUser).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe('getEventPayments', () => {
+    it('returns payments for event', async () => {
+      const payments = [{ id: 1, eventId: 10, amountPaid: 5000 }];
+      mockPaymentsService.getPaymentsByEvent.mockResolvedValue(payments);
+
+      const result = await controller.getEventPayments('10');
+
+      expect(result).toEqual(payments);
+      expect(mockPaymentsService.getPaymentsByEvent).toHaveBeenCalledWith(10);
+    });
+  });
+});

--- a/test/backend/payments.service.spec.ts
+++ b/test/backend/payments.service.spec.ts
@@ -1,0 +1,352 @@
+import 'reflect-metadata';
+
+jest.mock('../../src/backend/src/database/database.service', () => ({
+  DatabaseService: jest.fn(),
+}));
+jest.mock('../../src/backend/src/db/schema', () => ({
+  payments: {
+    id: 'payments.id',
+    userId: 'payments.userId',
+    eventId: 'payments.eventId',
+    ticketId: 'payments.ticketId',
+    stripeSessionId: 'payments.stripeSessionId',
+    stripePaymentIntentId: 'payments.stripePaymentIntentId',
+    stripeChargeId: 'payments.stripeChargeId',
+    amountPaid: 'payments.amountPaid',
+    currency: 'payments.currency',
+    status: 'payments.status',
+    refundedAmount: 'payments.refundedAmount',
+    paymentDate: 'payments.paymentDate',
+  },
+  users: { id: 'users.id', isSystemAdmin: 'users.isSystemAdmin' },
+}));
+
+import { PaymentsService } from '../../src/backend/src/payments/payments.service';
+
+const MockStripe = require('stripe');
+const mockRefundsCreate = MockStripe.mockRefundsCreate;
+
+function createDbChain(result: any = []) {
+  const chain: any = {};
+  chain.then = (resolve: any, reject: any) =>
+    Promise.resolve(result).then(resolve, reject);
+  chain.catch = (fn: any) => Promise.resolve(result).catch(fn);
+  [
+    'select',
+    'from',
+    'where',
+    'orderBy',
+    'limit',
+    'insert',
+    'values',
+    'update',
+    'set',
+  ].forEach((method) => {
+    chain[method] = jest.fn().mockReturnValue(chain);
+  });
+  return chain;
+}
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+  let mockDb: any;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.STRIPE_SECRET_KEY;
+
+    mockDb = {
+      select: jest.fn(),
+      insert: jest.fn(),
+      update: jest.fn(),
+    };
+    service = new PaymentsService({ db: mockDb } as any);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('createProductAndPrice', () => {
+    it('returns error when Stripe is not configured', async () => {
+      const result = await service.createProductAndPrice('Event', 1, 5000);
+      expect(result).toEqual({
+        error:
+          'Payment is not configured. Set STRIPE_SECRET_KEY in the server environment.',
+      });
+    });
+
+    it('returns error when price is zero or negative', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+      const serviceWithStripe = new PaymentsService({ db: mockDb } as any);
+
+      expect(await serviceWithStripe.createProductAndPrice('E', 1, 0)).toEqual({
+        error: 'Price must be greater than 0',
+      });
+      expect(await serviceWithStripe.createProductAndPrice('E', 1, -100)).toEqual({
+        error: 'Price must be greater than 0',
+      });
+    });
+  });
+
+  describe('createCheckoutSession', () => {
+    it('returns error when Stripe is not configured', async () => {
+      const result = await service.createCheckoutSession({
+        eventId: 1,
+        userId: 5,
+        amount: 5000,
+        eventName: 'Gala',
+        successUrl: 'https://a.com/success',
+        cancelUrl: 'https://a.com/cancel',
+      });
+      expect(result).toEqual({
+        error:
+          'Payment is not configured. Set STRIPE_SECRET_KEY in the server environment.',
+      });
+    });
+  });
+
+  describe('retrievePaymentDetails', () => {
+    it('returns null when session has no payment_intent', async () => {
+      const session = { payment_intent: null, amount_total: 5000, currency: 'usd' };
+      const result = await service.retrievePaymentDetails(session as any);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('recordPayment', () => {
+    it('inserts payment with correct fields', async () => {
+      const chain = createDbChain();
+      mockDb.insert.mockReturnValue(chain);
+
+      await service.recordPayment({
+        userId: 5,
+        eventId: 10,
+        ticketId: 1,
+        stripeSessionId: 'cs_123',
+        paymentIntentId: 'pi_123',
+        chargeId: 'ch_123',
+        amountPaid: 5000,
+        currency: 'usd',
+      });
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(chain.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 5,
+          eventId: 10,
+          ticketId: 1,
+          stripeSessionId: 'cs_123',
+          stripePaymentIntentId: 'pi_123',
+          stripeChargeId: 'ch_123',
+          amountPaid: 5000,
+          currency: 'usd',
+          status: 'succeeded',
+        }),
+      );
+    });
+  });
+
+  describe('refundPayment', () => {
+    it('returns error when user is not admin', async () => {
+      mockDb.select.mockReturnValue(createDbChain([]));
+
+      const result = await service.refundPayment(1, 99);
+
+      expect(result).toEqual({ error: 'Unauthorized: Admin access required' });
+    });
+
+    it('returns error when user is not system admin', async () => {
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 99, isSystemAdmin: false }]));
+
+      const result = await service.refundPayment(1, 99);
+
+      expect(result).toEqual({ error: 'Unauthorized: Admin access required' });
+    });
+
+    it('returns error when payment not found', async () => {
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([]));
+
+      const result = await service.refundPayment(999, 1);
+
+      expect(result).toEqual({ error: 'Payment not found' });
+    });
+
+    it('returns error when payment already fully refunded', async () => {
+      const payment = {
+        id: 1,
+        status: 'refunded',
+        stripePaymentIntentId: 'pi_1',
+        amountPaid: 5000,
+        refundedAmount: 5000,
+      };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([payment]));
+
+      const result = await service.refundPayment(1, 1);
+
+      expect(result).toEqual({ error: 'Payment already fully refunded' });
+    });
+
+    it('returns error when no Stripe charge or payment intent on payment', async () => {
+      const payment = {
+        id: 1,
+        status: 'succeeded',
+        stripePaymentIntentId: null,
+        stripeChargeId: null,
+        amountPaid: 5000,
+        refundedAmount: 0,
+      };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([payment]));
+
+      const result = await service.refundPayment(1, 1);
+
+      expect(result).toEqual({
+        error: 'No Stripe charge or payment intent found for this payment',
+      });
+    });
+
+    it('returns error when Stripe is not configured', async () => {
+      const payment = {
+        id: 1,
+        status: 'succeeded',
+        stripePaymentIntentId: 'pi_1',
+        stripeChargeId: 'ch_1',
+        amountPaid: 5000,
+        refundedAmount: 0,
+      };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([payment]));
+
+      const result = await service.refundPayment(1, 1);
+
+      expect(result).toEqual({ error: 'Stripe not configured' });
+    });
+
+    it('returns error when no amount left to refund', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+      const serviceWithStripe = new PaymentsService({ db: mockDb } as any);
+      const payment = {
+        id: 1,
+        status: 'succeeded',
+        stripePaymentIntentId: 'pi_1',
+        stripeChargeId: 'ch_1',
+        amountPaid: 5000,
+        refundedAmount: 5000,
+      };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([payment]));
+
+      const result = await serviceWithStripe.refundPayment(1, 1);
+
+      expect(result).toEqual({ error: 'No amount left to refund' });
+    });
+
+    it('issues full refund and updates payment when Stripe succeeds', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+      const serviceWithStripe = new PaymentsService({ db: mockDb } as any);
+
+      const payment = {
+        id: 1,
+        status: 'succeeded',
+        stripePaymentIntentId: 'pi_1',
+        stripeChargeId: 'ch_1',
+        amountPaid: 5000,
+        refundedAmount: 0,
+      };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([payment]));
+      mockDb.update.mockReturnValue(createDbChain());
+
+      const result = await serviceWithStripe.refundPayment(1, 1);
+
+      expect(result).toEqual({ success: true });
+      expect(mockRefundsCreate).toHaveBeenCalledWith({
+        payment_intent: 'pi_1',
+        amount: 5000,
+      });
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it('returns error when Stripe refund status is not succeeded', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+      const serviceWithStripe = new PaymentsService({ db: mockDb } as any);
+      mockRefundsCreate.mockResolvedValueOnce({ status: 'failed' });
+
+      const payment = {
+        id: 1,
+        status: 'succeeded',
+        stripePaymentIntentId: 'pi_1',
+        stripeChargeId: 'ch_1',
+        amountPaid: 5000,
+        refundedAmount: 0,
+      };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([payment]));
+
+      const result = await serviceWithStripe.refundPayment(1, 1);
+
+      expect(result).toEqual({ error: 'Refund failed: failed' });
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('returns error when Stripe refund throws', async () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+      const serviceWithStripe = new PaymentsService({ db: mockDb } as any);
+      mockRefundsCreate.mockRejectedValueOnce(new Error('Stripe API error'));
+
+      const payment = {
+        id: 1,
+        status: 'succeeded',
+        stripePaymentIntentId: 'pi_1',
+        stripeChargeId: 'ch_1',
+        amountPaid: 5000,
+        refundedAmount: 0,
+      };
+      mockDb.select
+        .mockReturnValueOnce(createDbChain([{ id: 1, isSystemAdmin: true }]))
+        .mockReturnValueOnce(createDbChain([payment]));
+
+      const result = await serviceWithStripe.refundPayment(1, 1);
+
+      expect(result).toEqual({ error: 'Stripe API error' });
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPaymentsByUser', () => {
+    it('returns payments from database', async () => {
+      const paymentsList = [{ id: 1, userId: 5, amountPaid: 5000 }];
+      mockDb.select.mockReturnValue(createDbChain(paymentsList));
+
+      const result = await service.getPaymentsByUser(5);
+
+      expect(result).toEqual(paymentsList);
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPaymentsByEvent', () => {
+    it('returns payments from database', async () => {
+      const paymentsList = [{ id: 1, eventId: 10, amountPaid: 5000 }];
+      mockDb.select.mockReturnValue(createDbChain(paymentsList));
+
+      const result = await service.getPaymentsByEvent(10);
+
+      expect(result).toEqual(paymentsList);
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/backend/refund-requests.controller.spec.ts
+++ b/test/backend/refund-requests.controller.spec.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import 'reflect-metadata';
 
 jest.mock('../../src/backend/src/refund-requests/refund-requests.service', () => ({

--- a/test/frontend/create-event.test.tsx
+++ b/test/frontend/create-event.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 

--- a/test/frontend/event-created.test.tsx
+++ b/test/frontend/event-created.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 

--- a/test/frontend/events-screen.test.tsx
+++ b/test/frontend/events-screen.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 

--- a/test/frontend/qr-scanner.test.tsx
+++ b/test/frontend/qr-scanner.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 

--- a/test/frontend/refund-requests.test.tsx
+++ b/test/frontend/refund-requests.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 

--- a/test/frontend/ticket-detail.test.tsx
+++ b/test/frontend/ticket-detail.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import { Alert } from 'react-native';

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node", "jest"]
+  },
+  "include": ["backend/**/*.ts", "frontend/**/*.ts", "frontend/**/*.tsx"]
+}


### PR DESCRIPTION

### PaymentsService (`payments.service.spec.ts`)
- **createProductAndPrice**: Stripe not configured; price ≤ 0.
- **createCheckoutSession**: Stripe not configured.
- **retrievePaymentDetails**: Returns null when session has no `payment_intent`.
- **recordPayment**: Inserts payment with correct fields (eventId, userId, ticketId, amount, Stripe ids, etc.).
- **refundPayment**: Not admin; payment not found; already fully refunded; no Stripe id; Stripe not configured; no amount left; **full refund success**; Stripe refund status ≠ succeeded; Stripe throws.
- **getPaymentsByUser** / **getPaymentsByEvent**: Return payments from DB.

### PaymentsController (`payments.controller.spec.ts`)
- **refundPayment**: Calls service with `paymentId`, `adminUserId`, optional `partialAmount`; passes `undefined` when `partialAmount` omitted.
- **getUserPayments**: Returns user payments; delegates to service with parsed user id.
- **getEventPayments**: Returns event payments; delegates to service with parsed event id.


### EventsService – payment flow (`events.service.spec.ts`)
- **createCheckoutSession**: Event not found; event has price but no Stripe price; event full; already signed up; **success** (calls `paymentsService.createCheckoutSession` with eventId, userId, amount, currency, eventName, successUrl, cancelUrl, and inserts seat reservation); payments service returns error (no reservation inserted).
- **completeSignupFromReservation**: Reservation not found; already has ticket; **success with paymentData** (creates ticket and calls `paymentsService.recordPayment` with userId, eventId, ticketId, stripeSessionId, payment intent/charge ids, amount, currency); success without paymentData (no `recordPayment` call).

### EventsController – payment flow (`events.controller.spec.ts`)
- **createCheckoutSession**: Passes event id, user id (`req.user.sub`), successUrl, cancelUrl, and optional `selectedTable` to service; returns service result.

